### PR TITLE
Enable ImGui Docking by default

### DIFF
--- a/Hesiod/src/gui/gui.cpp
+++ b/Hesiod/src/gui/gui.cpp
@@ -66,6 +66,7 @@ GLFWwindow *init_gui(int width, int height, std::string window_title)
   ImGuiIO &io = ImGui::GetIO();
   (void)io;
   io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+  io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
   ImGui::StyleColorsDark();
 


### PR DESCRIPTION
Example with docking:
![grafik](https://github.com/otto-link/Hesiod/assets/69595010/1c8e00e7-610e-4fc7-b1d4-e555bcf7e7a9)
