### PR TITLE
fix(gui): tint toolbar icons to follow the configured text color

### DIFF
--- a/Hesiod/include/hesiod/app/app_settings.hpp
+++ b/Hesiod/include/hesiod/app/app_settings.hpp
@@ -51,7 +51,14 @@ struct AppSettings
     explicit Icons();
     QIcon get(const std::string &name) const;
 
-    std::map<std::string, QIcon> icons_map; // populated in ctor
+    // Re-render icons, swapping the baked foreground color (#F4F4F5) for
+    // `color` so the icons follow the active palette. Call after the user
+    // settings (colors) have been loaded; multi-color icons (accent, black)
+    // are preserved.
+    void apply_text_color(const QColor &color);
+
+    std::map<std::string, QIcon>       icons_map;  // name -> (tinted) icon
+    std::map<std::string, std::string> icon_paths; // name -> absolute .svg path
   } icons;
 
   struct Global

--- a/Hesiod/src/app/app_settings.cpp
+++ b/Hesiod/src/app/app_settings.cpp
@@ -1,8 +1,14 @@
 /* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General
  * Public License. The full license is in the file LICENSE, distributed with
  * this software. */
+#include <QBuffer>
+#include <QByteArray>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
+#include <QImage>
+#include <QImageReader>
+#include <QPixmap>
 
 #include "highmap/opencl/gpu_opencl.hpp"
 
@@ -35,8 +41,44 @@ AppSettings::Icons::Icons()
   for (const QFileInfo &file_info : file_list)
   {
     QString fileName = file_info.baseName(); // name without extension
-    QIcon   icon(file_info.absoluteFilePath());
-    this->icons_map[fileName.toStdString()] = icon;
+    // keep the source path so icons can be re-tinted once the palette is
+    // loaded (see apply_text_color); load an untinted icon for now
+    this->icon_paths[fileName.toStdString()] = file_info.absoluteFilePath()
+                                                   .toStdString();
+    this->icons_map[fileName.toStdString()] = QIcon(file_info.absoluteFilePath());
+  }
+}
+
+void AppSettings::Icons::apply_text_color(const QColor &color)
+{
+  Logger::log()->trace("AppSettings::Icons::apply_text_color: {}",
+                       color.name().toStdString());
+
+  // The icon SVGs bake in the dark-theme foreground (#F4F4F5). Swap it for
+  // the active text color so the icons follow the palette; other colors
+  // (accent #5E81AC, black, ...) are left untouched.
+  const QByteArray target = color.name().toUtf8();
+
+  for (const auto &[name, path] : this->icon_paths)
+  {
+    QFile file(QString::fromStdString(path));
+    if (!file.open(QIODevice::ReadOnly))
+      continue;
+
+    QByteArray data = file.readAll();
+    file.close();
+
+    data.replace("#F4F4F5", target);
+    data.replace("#f4f4f5", target);
+
+    QBuffer      buffer(&data);
+    QImageReader reader(&buffer, "svg");
+    reader.setScaledSize(QSize(64, 64)); // render crisp, let Qt downscale
+    const QImage image = reader.read();
+    if (image.isNull())
+      continue; // svg image plugin missing or unreadable; keep default icon
+
+    this->icons_map[name] = QIcon(QPixmap::fromImage(image));
   }
 }
 

--- a/Hesiod/src/gui/utils/apply_global_style.cpp
+++ b/Hesiod/src/gui/utils/apply_global_style.cpp
@@ -41,6 +41,9 @@ void apply_global_style(QApplication &app)
 
   app.setStyleSheet(style_sheet.c_str());
 
+  // re-tint icons to match the (now loaded) palette text color
+  ctx.app_settings.icons.apply_text_color(ctx.app_settings.colors.text_primary);
+
   // graph viewer style
   {
     gngui::Style *p_style = gngui::Style::get_style().get();


### PR DESCRIPTION
## Problem

The per-node settings toolbar icons are SVGs that hard-code `fill="#F4F4F5"` — the *default* dark-theme `text_primary`. Since the UI palette is user-configurable (`app_settings.colors`, applied through `darkstyle.css` in `apply_global_style`), any light color scheme leaves the icons light-on-light and effectively invisible. The icons were themed by a different mechanism than the rest of the chrome.

## Fix

- `AppSettings::Icons` now stores each icon's source path and adds `apply_text_color(const QColor&)`, which re-renders every icon while replacing `#F4F4F5` with the active `colors.text_primary`. Other colors (e.g. the accent `#5E81AC`, black) are left untouched, so multi-color icons are preserved.
- `apply_global_style()` invokes it once the palette has been loaded.

The constructor still loads the icons up front, so behaviour is unchanged until the palette is known.

## Screenshot

Toolbar icons rendering correctly in the themed UI:

![toolbar icons rendering](https://raw.githubusercontent.com/barrulus/Hesiod/asset-icon-fix-screenshot/icon-fix.png)

## Note for local/dev builds

Rendering SVG `QIcon`s requires the **qtsvg** plugin on `QT_PLUGIN_PATH`. An unwrapped dev binary run directly (e.g. `./build/bin/hesiod`) will otherwise show blank icons regardless of this change; the packaged app (`wrapQtAppsHook`) is unaffected.
