### PR TITLE
fix(nodes): WaveSine phase units, SetBorders per-edge + N/S fix, HydraulicParticle flat warning, coord docs

### DIFF
--- a/Hesiod/data/node_documentation.json
+++ b/Hesiod/data/node_documentation.json
@@ -233,7 +233,7 @@
         "label": "Badlands",
         "parameters": {
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -1100,7 +1100,7 @@
         "label": "Bump",
         "parameters": {
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -1199,7 +1199,7 @@
         "label": "BumpLorentzian",
         "parameters": {
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -1253,7 +1253,7 @@
                 "type": "Float"
             },
             "radius": {
-                "description": "Filter radius with respect to the domain size.",
+                "description": "Filter radius with respect to the domain size. Specified in domain units (same scale as center); on a non-square map the footprint is therefore elliptical, since x and y span different physical extents.",
                 "key": "radius",
                 "label": "radius",
                 "type": "Float"
@@ -1304,7 +1304,7 @@
         "label": "Caldera",
         "parameters": {
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -1358,7 +1358,7 @@
                 "type": "Float"
             },
             "radius": {
-                "description": "Crater radius.",
+                "description": "Crater radius. Specified in domain units (same scale as center); on a non-square map the footprint is therefore elliptical, since x and y span different physical extents.",
                 "key": "radius",
                 "label": "radius",
                 "type": "Float"
@@ -1508,13 +1508,13 @@
         "label": "ClampOblique",
         "parameters": {
             "angle": {
-                "description": "Angle of the oblique plane, defining its orientation.",
+                "description": "Angle of the oblique plane, defining its orientation. Expressed in degrees.",
                 "key": "angle",
                 "label": "Angle",
                 "type": "Float"
             },
             "center": {
-                "description": "Center point of the oblique plane used for clamping.",
+                "description": "Center point of the oblique plane used for clamping. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "Center",
                 "type": "Vec2Float"
@@ -2871,7 +2871,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "Center position of the cone in world coordinate space.",
+                "description": "Center position of the cone in world coordinate space. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -2994,7 +2994,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "Center position of the cone in world coordinate space.",
+                "description": "Center position of the cone in world coordinate space. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -3072,7 +3072,7 @@
                 "type": "Float"
             },
             "radius": {
-                "description": "Effective radius of the cone in coordinate space units.",
+                "description": "Effective radius of the cone in coordinate space units. Specified in domain units (same scale as center); on a non-square map the footprint is therefore elliptical, since x and y span different physical extents.",
                 "key": "radius",
                 "label": "radius",
                 "type": "Float"
@@ -3153,7 +3153,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "Center position of the cone in world coordinate space.",
+                "description": "Center position of the cone in world coordinate space. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -3207,7 +3207,7 @@
                 "type": "Float"
             },
             "radius": {
-                "description": "Effective radius of the cone in coordinate space units.",
+                "description": "Effective radius of the cone in coordinate space units. Specified in domain units (same scale as center); on a non-square map the footprint is therefore elliptical, since x and y span different physical extents.",
                 "key": "radius",
                 "label": "radius",
                 "type": "Float"
@@ -3417,7 +3417,7 @@
         "label": "Crater",
         "parameters": {
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "Rotation Angle",
                 "type": "Float"
@@ -3429,7 +3429,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "Center",
                 "type": "Vec2Float"
@@ -3561,7 +3561,7 @@
                 "type": "Float"
             },
             "radius": {
-                "description": "Crater radius.",
+                "description": "Crater radius. Specified in domain units (same scale as center); on a non-square map the footprint is therefore elliptical, since x and y span different physical extents.",
                 "key": "radius",
                 "label": "Crater Radius",
                 "type": "Float"
@@ -4243,7 +4243,7 @@
         "label": "DirectionalBlur",
         "parameters": {
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -6106,7 +6106,7 @@
         "label": "GaborWaveFbm",
         "parameters": {
             "angle": {
-                "description": "Controls the base orientation of the Gabor wavelets, influencing the dominant direction of the noise pattern.",
+                "description": "Controls the base orientation of the Gabor wavelets, influencing the dominant direction of the noise pattern. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -6667,7 +6667,7 @@
         "label": "GaussianPulse",
         "parameters": {
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -6709,7 +6709,7 @@
                 "type": "Float"
             },
             "radius": {
-                "description": "Pulse half-width.",
+                "description": "Pulse half-width. Specified in domain units (same scale as center); on a non-square map the footprint is therefore elliptical, since x and y span different physical extents.",
                 "key": "radius",
                 "label": "radius",
                 "type": "Float"
@@ -6760,7 +6760,7 @@
                 "type": "Float"
             },
             "angle": {
-                "description": "Sets the primary orientation of the wave structures in the noise.",
+                "description": "Sets the primary orientation of the wave structures in the noise. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -7714,7 +7714,7 @@
     },
     "HydraulicParticle": {
         "category": "Erosion/Hydraulic",
-        "description": "HydraulicParticle is a particle-based hydraulic erosion operator that simulates the erosion and sediment transport processes that occur due to the flow of water over a terrain represented by the input heightmap. This type of operator models erosion by tracking the movement of virtual particles (or sediment particles) as they are transported by water flow and interact with the terrain.",
+        "description": "HydraulicParticle is a particle-based hydraulic erosion operator that simulates the erosion and sediment transport processes that occur due to the flow of water over a terrain represented by the input heightmap. This type of operator models erosion by tracking the movement of virtual particles (or sediment particles) as they are transported by water flow and interact with the terrain. Erosion is gradient-driven: flat or masked-to-zero input has no slope and produces little or no change. Erode full-domain relief first, then multiply by the land mask.",
         "label": "HydraulicParticle",
         "parameters": {
             "angle_bias": {
@@ -9230,7 +9230,7 @@
         "label": "IslandLandMask",
         "parameters": {
             "center": {
-                "description": "No description",
+                "description": "No description Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -9320,7 +9320,7 @@
                 "type": "Float"
             },
             "radius": {
-                "description": "No description",
+                "description": "No description Specified in domain units (same scale as center); on a non-square map the footprint is therefore elliptical, since x and y span different physical extents.",
                 "key": "radius",
                 "label": "radius",
                 "type": "Float"
@@ -9419,7 +9419,7 @@
         "label": "KernelGabor",
         "parameters": {
             "angle": {
-                "description": "Kernel angle.",
+                "description": "Kernel angle. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -10757,7 +10757,7 @@
         "label": "MountainCone",
         "parameters": {
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -10769,7 +10769,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "No description",
+                "description": "No description Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -10910,7 +10910,7 @@
                 "type": "Bool"
             },
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -10928,7 +10928,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "No description",
+                "description": "No description Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -11069,7 +11069,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "The center point of the radial mountain range as normalized coordinates within [0, 1].",
+                "description": "The center point of the radial mountain range as normalized coordinates within [0, 1]. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -11210,7 +11210,7 @@
                 "type": "Bool"
             },
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -11222,7 +11222,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "No description",
+                "description": "No description Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -11357,7 +11357,7 @@
                 "type": "Bool"
             },
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -11381,7 +11381,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "No description",
+                "description": "No description Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -11633,7 +11633,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "2D center point of the rotated step axis, expressed in normalized domain coordinates.",
+                "description": "2D center point of the rotated step axis, expressed in normalized domain coordinates. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "Center",
                 "type": "Vec2Float"
@@ -12899,7 +12899,7 @@
                 "type": "Float"
             },
             "angle": {
-                "description": "Angle.",
+                "description": "Angle. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -12911,7 +12911,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -14889,7 +14889,7 @@
         "label": "RadialDisplacementToXy",
         "parameters": {
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -15030,7 +15030,7 @@
                 "type": "Float"
             },
             "angle": {
-                "description": "TODO",
+                "description": "TODO Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -15755,7 +15755,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "Center",
                 "type": "Vec2Float"
@@ -15857,7 +15857,7 @@
                 "type": "Float"
             },
             "radius": {
-                "description": "Half-width of the rift in normalized domain units.",
+                "description": "Half-width of the rift in normalized domain units. Specified in domain units (same scale as center); on a non-square map the footprint is therefore elliptical, since x and y span different physical extents.",
                 "key": "radius",
                 "label": "Radius",
                 "type": "Float"
@@ -15914,7 +15914,7 @@
                 "type": "Float"
             },
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -15926,7 +15926,7 @@
                 "type": "Bool"
             },
             "center": {
-                "description": "No description",
+                "description": "No description Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -16151,7 +16151,7 @@
         "label": "Rotate",
         "parameters": {
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -16184,7 +16184,7 @@
         "label": "RotateDisplacement",
         "parameters": {
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -16550,7 +16550,7 @@
         "label": "SelectAngle",
         "parameters": {
             "angle": {
-                "description": "Selection center value.",
+                "description": "Selection center value. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -16919,7 +16919,7 @@
         "label": "SelectInwardOutward",
         "parameters": {
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -17877,6 +17877,36 @@
                 "key": "value_west",
                 "label": "value_west",
                 "type": "Float"
+            },
+            "radius_west": {
+                "key": "radius_west",
+                "label": "radius_west",
+                "type": "Float",
+                "description": "West-edge buffer thickness (fraction of width)."
+            },
+            "radius_east": {
+                "key": "radius_east",
+                "label": "radius_east",
+                "type": "Float",
+                "description": "East-edge buffer thickness (fraction of width)."
+            },
+            "radius_north": {
+                "key": "radius_north",
+                "label": "radius_north",
+                "type": "Float",
+                "description": "North (top) edge buffer thickness (fraction of height)."
+            },
+            "radius_south": {
+                "key": "radius_south",
+                "label": "radius_south",
+                "type": "Float",
+                "description": "South (bottom) edge buffer thickness (fraction of height)."
+            },
+            "unique_border_radius": {
+                "key": "unique_border_radius",
+                "label": "unique_border_radius",
+                "type": "Bool",
+                "description": "When true, use the single `radius` for all edges; when false, use the per-edge radii. N/S buffers scale by map height, E/W by width."
             }
         },
         "ports": {
@@ -18008,7 +18038,7 @@
                 "type": "Bool"
             },
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -18026,7 +18056,7 @@
                 "type": "Float"
             },
             "center": {
-                "description": "No description",
+                "description": "No description Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -18203,13 +18233,13 @@
         "label": "Slope",
         "parameters": {
             "angle": {
-                "description": "Angle.",
+                "description": "Angle. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
             },
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -19205,7 +19235,7 @@
         "label": "SteepenConvective",
         "parameters": {
             "angle": {
-                "description": "TODO",
+                "description": "TODO Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -19256,13 +19286,13 @@
         "label": "Step",
         "parameters": {
             "angle": {
-                "description": "Angle.",
+                "description": "Angle. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
             },
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -19349,7 +19379,7 @@
         "label": "Strata",
         "parameters": {
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -19586,7 +19616,7 @@
                 "type": "Float"
             },
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "Orientation Angle",
                 "type": "Float"
@@ -21343,7 +21373,7 @@
         "label": "Translate",
         "parameters": {
             "center": {
-                "description": "No description",
+                "description": "No description Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"
@@ -21709,7 +21739,7 @@
         "label": "Vorolines",
         "parameters": {
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -21826,7 +21856,7 @@
         "label": "VorolinesFbm",
         "parameters": {
             "angle": {
-                "description": "No description",
+                "description": "Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -22965,7 +22995,7 @@
         "label": "WaveDune",
         "parameters": {
             "angle": {
-                "description": "Angle in the horizontal plane.",
+                "description": "Angle in the horizontal plane. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -23070,19 +23100,19 @@
         "label": "WaveSine",
         "parameters": {
             "angle": {
-                "description": "Angle in the horizontal plane.",
+                "description": "Angle in the horizontal plane. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
             },
             "kw": {
-                "description": "Base spatial frequencies in the X and Y directions. The frequencies are defined with respect to the entire domain: for example, kw = 2 produces two full oscillations across the domain width (and similarly for the Y direction).",
+                "description": "Base spatial frequencies in the X and Y directions. The frequencies are defined with respect to the entire domain: for example, kw = 2 produces two full oscillations across the domain width (and similarly for the Y direction). Wavenumber in cycles across the unit domain (applied to both X and Y).",
                 "key": "kw",
                 "label": "kw",
                 "type": "Float"
             },
             "phase_shift": {
-                "description": "Phase shift.",
+                "description": "Phase shift. In degrees. Phase offset of cos(2*pi*r + phase); the wave is measured from the domain origin (0,0) and is not symmetric about the centre.",
                 "key": "phase_shift",
                 "label": "phase_shift",
                 "type": "Float"
@@ -23163,7 +23193,7 @@
         "label": "WaveSquare",
         "parameters": {
             "angle": {
-                "description": "Angle in the horizontal plane.",
+                "description": "Angle in the horizontal plane. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -23256,7 +23286,7 @@
         "label": "WaveTriangular",
         "parameters": {
             "angle": {
-                "description": "Angle in the horizontal plane.",
+                "description": "Angle in the horizontal plane. Expressed in degrees.",
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
@@ -23820,7 +23850,7 @@
         "label": "Zoom",
         "parameters": {
             "center": {
-                "description": "Reference center within the heightmap.",
+                "description": "Reference center within the heightmap. Coordinates are in domain units; center.y is measured from the bottom of the map (y increases upward).",
                 "key": "center",
                 "label": "center",
                 "type": "Vec2Float"

--- a/Hesiod/src/model/nodes/nodes_function/hydraulic_particle.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/hydraulic_particle.cpp
@@ -228,6 +228,17 @@ void compute_hydraulic_particle_node(BaseNode &node)
   float hmin = p_in->min(node.cfg().cm_cpu);
   float hmax = p_in->max(node.cfg().cm_cpu);
 
+  // Particle erosion is gradient-driven: flat or masked-to-zero input has no
+  // slope, so particles carry no sediment and the output is unchanged. Warn
+  // rather than silently returning the input untouched.
+  if (hmax - hmin < 1.0e-6f)
+    Logger::log()->warn(
+        "HydraulicParticle [{}]: input is flat/near-constant (value range ~ 0). "
+        "Erosion is gradient-driven and will produce little or no change. "
+        "Erode full-domain relief first, then multiply by the land mask; "
+        "or enable ridge forcing.",
+        node.get_id());
+
   hmap::for_each_tile(
       {p_in, p_bedrock, p_moisture, p_mask},
       {p_out, p_erosion, p_deposition},

--- a/Hesiod/src/model/nodes/nodes_function/hydraulic_particle.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/hydraulic_particle.cpp
@@ -232,12 +232,15 @@ void compute_hydraulic_particle_node(BaseNode &node)
   // slope, so particles carry no sediment and the output is unchanged. Warn
   // rather than silently returning the input untouched.
   if (hmax - hmin < 1.0e-6f)
+  {
     Logger::log()->warn(
         "HydraulicParticle [{}]: input is flat/near-constant (value range ~ 0). "
         "Erosion is gradient-driven and will produce little or no change. "
         "Erode full-domain relief first, then multiply by the land mask; "
         "or enable ridge forcing.",
         node.get_id());
+    return;
+  }
 
   hmap::for_each_tile(
       {p_in, p_bedrock, p_moisture, p_mask},

--- a/Hesiod/src/model/nodes/nodes_function/set_borders.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/set_borders.cpp
@@ -24,6 +24,11 @@ void setup_set_borders_node(BaseNode &node)
 
   // attribute(s)
   node.add_attr<FloatAttribute>("radius", "radius", 0.4f, 0.f, 0.5f);
+  node.add_attr<BoolAttribute>("unique_border_radius", "unique_border_radius", true);
+  node.add_attr<FloatAttribute>("radius_west", "radius_west", 0.4f, 0.f, 0.5f);
+  node.add_attr<FloatAttribute>("radius_east", "radius_east", 0.4f, 0.f, 0.5f);
+  node.add_attr<FloatAttribute>("radius_north", "radius_north", 0.4f, 0.f, 0.5f);
+  node.add_attr<FloatAttribute>("radius_south", "radius_south", 0.4f, 0.f, 0.5f);
   node.add_attr<BoolAttribute>("unique_border_value", "unique_border_value", false);
   node.add_attr<FloatAttribute>("value_west", "value_west", -0.5f, -FLT_MAX, FLT_MAX);
   node.add_attr<FloatAttribute>("value_east", "value_east", 0.5f, -FLT_MAX, FLT_MAX);
@@ -32,8 +37,13 @@ void setup_set_borders_node(BaseNode &node)
 
   // attribute(s) order
   node.set_attr_ordered_key({"radius",
-                             "unique_border_value",
+                             "unique_border_radius",
+                             "radius_west",
+                             "radius_east",
+                             "radius_north",
+                             "radius_south",
                              "_SEPARATOR_",
+                             "unique_border_value",
                              "value_west",
                              "value_east",
                              "value_north",
@@ -50,21 +60,39 @@ void compute_set_borders_node(BaseNode &node)
   {
     hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>("output");
 
-    int ir = std::max(1, (int)(node.get_attr<FloatAttribute>("radius") * p_in->shape.x));
-    glm::ivec4 buffer_sizes(ir, ir, ir, ir);
+    // Per-edge buffer thickness, scaled by the axis each edge runs along
+    // (E/W along x, N/S along y) so caps are predictable on non-square maps.
+    auto to_px_x = [&](float r) { return std::max(1, (int)(r * p_in->shape.x)); };
+    auto to_px_y = [&](float r) { return std::max(1, (int)(r * p_in->shape.y)); };
+
+    int rw, re, rn, rs;
+    if (node.get_attr<BoolAttribute>("unique_border_radius"))
+    {
+      const float r = node.get_attr<FloatAttribute>("radius");
+      rw = re = to_px_x(r);
+      rn = rs = to_px_y(r);
+    }
+    else
+    {
+      rw = to_px_x(node.get_attr<FloatAttribute>("radius_west"));
+      re = to_px_x(node.get_attr<FloatAttribute>("radius_east"));
+      rn = to_px_y(node.get_attr<FloatAttribute>("radius_north"));
+      rs = to_px_y(node.get_attr<FloatAttribute>("radius_south"));
+    }
+
+    // engine order: {west=.x, east=.y, south=.z, north=.w}
+    glm::ivec4 buffer_sizes(rw, re, rs, rn);
+
+    const float vw = node.get_attr<FloatAttribute>("value_west");
+    const float ve = node.get_attr<FloatAttribute>("value_east");
+    const float vn = node.get_attr<FloatAttribute>("value_north");
+    const float vs = node.get_attr<FloatAttribute>("value_south");
 
     glm::vec4 border_values;
-
     if (node.get_attr<BoolAttribute>("unique_border_value"))
-      border_values = {node.get_attr<FloatAttribute>("value_west"),
-                       node.get_attr<FloatAttribute>("value_west"),
-                       node.get_attr<FloatAttribute>("value_west"),
-                       node.get_attr<FloatAttribute>("value_west")};
+      border_values = {vw, vw, vw, vw};
     else
-      border_values = {node.get_attr<FloatAttribute>("value_west"),
-                       node.get_attr<FloatAttribute>("value_east"),
-                       node.get_attr<FloatAttribute>("value_north"),
-                       node.get_attr<FloatAttribute>("value_south")};
+      border_values = {vw, ve, vs, vn}; // {west, east, south, north} per engine
 
     hmap::for_each_tile(
         {p_out, p_in},

--- a/Hesiod/src/model/nodes/nodes_function/set_borders.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/set_borders.cpp
@@ -14,98 +14,155 @@ using namespace attr;
 namespace hesiod
 {
 
+// -----------------------------------------------------------------------------
+// Ports & Attributes
+// -----------------------------------------------------------------------------
+
+constexpr const char *P_IN = "input";
+constexpr const char *P_OUT = "output";
+
+constexpr const char *A_RADIUS = "radius";
+constexpr const char *A_UNIFORM_RADIUS = "uniform_radius";
+constexpr const char *A_RADIUS_WEST = "radius_west";
+constexpr const char *A_RADIUS_EAST = "radius_east";
+constexpr const char *A_RADIUS_NORTH = "radius_north";
+constexpr const char *A_RADIUS_SOUTH = "radius_south";
+constexpr const char *A_UNIFORM_VALUE = "uniform_value";
+constexpr const char *A_VALUE_WEST = "value_west";
+constexpr const char *A_VALUE_EAST = "value_east";
+constexpr const char *A_VALUE_NORTH = "value_north";
+constexpr const char *A_VALUE_SOUTH = "value_south";
+
+// -----------------------------------------------------------------------------
+// Setup
+// -----------------------------------------------------------------------------
+
 void setup_set_borders_node(BaseNode &node)
 {
   Logger::log()->trace("setup node {}", node.get_label());
 
-  // port(s)
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "input");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, "output", CONFIG(node));
+  // --- Ports
 
-  // attribute(s)
-  node.add_attr<FloatAttribute>("radius", "radius", 0.4f, 0.f, 0.5f);
-  node.add_attr<BoolAttribute>("unique_border_radius", "unique_border_radius", true);
-  node.add_attr<FloatAttribute>("radius_west", "radius_west", 0.4f, 0.f, 0.5f);
-  node.add_attr<FloatAttribute>("radius_east", "radius_east", 0.4f, 0.f, 0.5f);
-  node.add_attr<FloatAttribute>("radius_north", "radius_north", 0.4f, 0.f, 0.5f);
-  node.add_attr<FloatAttribute>("radius_south", "radius_south", 0.4f, 0.f, 0.5f);
-  node.add_attr<BoolAttribute>("unique_border_value", "unique_border_value", false);
-  node.add_attr<FloatAttribute>("value_west", "value_west", -0.5f, -FLT_MAX, FLT_MAX);
-  node.add_attr<FloatAttribute>("value_east", "value_east", 0.5f, -FLT_MAX, FLT_MAX);
-  node.add_attr<FloatAttribute>("value_north", "value_north", 0.5f, -FLT_MAX, FLT_MAX);
-  node.add_attr<FloatAttribute>("value_south", "value_south", -0.5f, -FLT_MAX, FLT_MAX);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_IN);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, P_OUT, CONFIG(node));
 
-  // attribute(s) order
-  node.set_attr_ordered_key({"radius",
-                             "unique_border_radius",
-                             "radius_west",
-                             "radius_east",
-                             "radius_north",
-                             "radius_south",
-                             "_SEPARATOR_",
-                             "unique_border_value",
-                             "value_west",
-                             "value_east",
-                             "value_north",
-                             "value_south"});
+  // --- Attributes
+
+  // clang-format off
+  node.add_attr<FloatAttribute>(A_RADIUS, "Radius", 0.4f, 0.f, 0.5f);
+  node.add_attr<BoolAttribute>(A_UNIFORM_RADIUS, "Uniform Radius", true);
+  node.add_attr<FloatAttribute>(A_RADIUS_WEST,  "West",  0.4f, 0.f, 0.5f);
+  node.add_attr<FloatAttribute>(A_RADIUS_EAST,  "East",  0.4f, 0.f, 0.5f);
+  node.add_attr<FloatAttribute>(A_RADIUS_NORTH, "North", 0.4f, 0.f, 0.5f);
+  node.add_attr<FloatAttribute>(A_RADIUS_SOUTH, "South", 0.4f, 0.f, 0.5f);
+  node.add_attr<BoolAttribute>(A_UNIFORM_VALUE, "Uniform Value", false);
+  node.add_attr<FloatAttribute>(A_VALUE_WEST,  "West",  -0.5f, -FLT_MAX, FLT_MAX);
+  node.add_attr<FloatAttribute>(A_VALUE_EAST,  "East",   0.5f, -FLT_MAX, FLT_MAX);
+  node.add_attr<FloatAttribute>(A_VALUE_NORTH, "North",  0.5f, -FLT_MAX, FLT_MAX);
+  node.add_attr<FloatAttribute>(A_VALUE_SOUTH, "South", -0.5f, -FLT_MAX, FLT_MAX);
+  // clang-format on
+
+  // --- Attribute order
+
+  node.set_attr_ordered_key({
+      "_GROUPBOX_BEGIN_Border Radius",
+      A_RADIUS,
+      A_UNIFORM_RADIUS,
+      A_RADIUS_WEST,
+      A_RADIUS_EAST,
+      A_RADIUS_NORTH,
+      A_RADIUS_SOUTH,
+      "_GROUPBOX_END_",
+      //
+      "_GROUPBOX_BEGIN_Border Values",
+      A_UNIFORM_VALUE,
+      A_VALUE_WEST,
+      A_VALUE_EAST,
+      A_VALUE_NORTH,
+      A_VALUE_SOUTH,
+      "_GROUPBOX_END_",
+  });
 }
+
+// -----------------------------------------------------------------------------
+// Compute
+// -----------------------------------------------------------------------------
 
 void compute_set_borders_node(BaseNode &node)
 {
   Logger::log()->trace("computing node [{}]/[{}]", node.get_label(), node.get_id());
 
-  hmap::VirtualArray *p_in = node.get_value_ref<hmap::VirtualArray>("input");
+  // --- Inputs / Outputs
 
-  if (p_in)
+  auto *p_in = node.get_value_ref<hmap::VirtualArray>(P_IN);
+  auto *p_out = node.get_value_ref<hmap::VirtualArray>(P_OUT);
+
+  if (!p_in || !p_out)
+    return;
+
+  // --- Helpers
+
+  const auto to_px_x = [&](float r) { return std::max(1, int(r * p_in->shape.x)); };
+
+  const auto to_px_y = [&](float r) { return std::max(1, int(r * p_in->shape.y)); };
+
+  // --- Border radii
+
+  // engine order: {west=.x, east=.y, south=.z, north=.w}
+  glm::ivec4 buffer_sizes;
+
+  if (node.get_attr<BoolAttribute>(A_UNIFORM_RADIUS))
   {
-    hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>("output");
+    const float r = node.get_attr<FloatAttribute>(A_RADIUS);
 
-    // Per-edge buffer thickness, scaled by the axis each edge runs along
-    // (E/W along x, N/S along y) so caps are predictable on non-square maps.
-    auto to_px_x = [&](float r) { return std::max(1, (int)(r * p_in->shape.x)); };
-    auto to_px_y = [&](float r) { return std::max(1, (int)(r * p_in->shape.y)); };
-
-    int rw, re, rn, rs;
-    if (node.get_attr<BoolAttribute>("unique_border_radius"))
-    {
-      const float r = node.get_attr<FloatAttribute>("radius");
-      rw = re = to_px_x(r);
-      rn = rs = to_px_y(r);
-    }
-    else
-    {
-      rw = to_px_x(node.get_attr<FloatAttribute>("radius_west"));
-      re = to_px_x(node.get_attr<FloatAttribute>("radius_east"));
-      rn = to_px_y(node.get_attr<FloatAttribute>("radius_north"));
-      rs = to_px_y(node.get_attr<FloatAttribute>("radius_south"));
-    }
-
-    // engine order: {west=.x, east=.y, south=.z, north=.w}
-    glm::ivec4 buffer_sizes(rw, re, rs, rn);
-
-    const float vw = node.get_attr<FloatAttribute>("value_west");
-    const float ve = node.get_attr<FloatAttribute>("value_east");
-    const float vn = node.get_attr<FloatAttribute>("value_north");
-    const float vs = node.get_attr<FloatAttribute>("value_south");
-
-    glm::vec4 border_values;
-    if (node.get_attr<BoolAttribute>("unique_border_value"))
-      border_values = {vw, vw, vw, vw};
-    else
-      border_values = {vw, ve, vs, vn}; // {west, east, south, north} per engine
-
-    hmap::for_each_tile(
-        {p_out, p_in},
-        [border_values, buffer_sizes](std::vector<hmap::Array *> p_arrays,
-                                      const hmap::TileRegion &)
-        {
-          auto [pa_out, pa_in] = unpack<2>(p_arrays);
-          *pa_out = *pa_in;
-
-          hmap::set_borders(*pa_out, border_values, buffer_sizes);
-        },
-        node.cfg().cm_single_array);
+    buffer_sizes = {
+        to_px_x(r), // west
+        to_px_x(r), // east
+        to_px_y(r), // south
+        to_px_y(r)  // north
+    };
   }
+  else
+  {
+    buffer_sizes = {to_px_x(node.get_attr<FloatAttribute>(A_RADIUS_WEST)),
+                    to_px_x(node.get_attr<FloatAttribute>(A_RADIUS_EAST)),
+                    to_px_y(node.get_attr<FloatAttribute>(A_RADIUS_SOUTH)),
+                    to_px_y(node.get_attr<FloatAttribute>(A_RADIUS_NORTH))};
+  }
+
+  // --- Border values
+
+  const float vw = node.get_attr<FloatAttribute>(A_VALUE_WEST);
+  const float ve = node.get_attr<FloatAttribute>(A_VALUE_EAST);
+  const float vn = node.get_attr<FloatAttribute>(A_VALUE_NORTH);
+  const float vs = node.get_attr<FloatAttribute>(A_VALUE_SOUTH);
+
+  glm::vec4 border_values;
+
+  if (node.get_attr<BoolAttribute>(A_UNIFORM_VALUE))
+  {
+    border_values = {vw, vw, vw, vw};
+  }
+  else
+  {
+    // engine order: {west, east, south, north}
+    border_values = {vw, ve, vs, vn};
+  }
+
+  // --- Compute
+
+  hmap::for_each_tile(
+      {p_out, p_in},
+      [buffer_sizes, border_values](std::vector<hmap::Array *> p_arrays,
+                                    const hmap::TileRegion &)
+      {
+        auto [pa_out, pa_in] = unpack<2>(p_arrays);
+
+        *pa_out = *pa_in;
+
+        hmap::set_borders(*pa_out, border_values, buffer_sizes);
+      },
+      node.cfg().cm_single_array);
 }
 
 } // namespace hesiod

--- a/Hesiod/src/model/nodes/nodes_function/slope.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/slope.cpp
@@ -25,7 +25,7 @@ void setup_slope_node(BaseNode &node)
   node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, "output", CONFIG(node));
 
   // attribute(s)
-  node.add_attr<FloatAttribute>("angle", "angle", 0.f, -180.f, 180.f);
+  node.add_attr<FloatAttribute>("angle", "angle", 0.f, -180.f, 180.f, "{:.1f}°");
   node.add_attr<FloatAttribute>("talus_global", "talus_global", 2.f, 0.01f, FLT_MAX);
   node.add_attr<Vec2FloatAttribute>("center", "center");
 

--- a/Hesiod/src/model/nodes/nodes_function/step.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/step.cpp
@@ -26,7 +26,7 @@ void setup_step_node(BaseNode &node)
   node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, "output", CONFIG(node));
 
   // attribute(s)
-  node.add_attr<FloatAttribute>("angle", "angle", 0.f, -180.f, 180.f);
+  node.add_attr<FloatAttribute>("angle", "angle", 0.f, -180.f, 180.f, "{:.1f}°");
   node.add_attr<FloatAttribute>("slope", "slope", 2.f, 0.01f, FLT_MAX);
   node.add_attr<Vec2FloatAttribute>("center", "center");
 

--- a/Hesiod/src/model/nodes/nodes_function/wave_sine.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/wave_sine.cpp
@@ -51,10 +51,15 @@ void compute_wave_sine_node(BaseNode &node)
         hmap::Array *pa_out = p_arrays[0];
         hmap::Array *pa_dr = p_arrays[1];
 
+        // phase_shift slider is in degrees (range -180..180, matching `angle`);
+        // hmap::wave_sine expects radians in cos(2*pi*r + phase). Convert here.
+        const float phase_rad = node.get_attr<FloatAttribute>("phase_shift") *
+                                (float)(M_PI / 180.0);
+
         *pa_out = hmap::wave_sine(region.shape,
                                   node.get_attr<FloatAttribute>("kw"),
                                   node.get_attr<FloatAttribute>("angle"),
-                                  node.get_attr<FloatAttribute>("phase_shift"),
+                                  phase_rad,
                                   pa_dr,
                                   nullptr,
                                   nullptr,

--- a/Hesiod/src/model/nodes/nodes_function/wave_sine.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/wave_sine.cpp
@@ -14,51 +14,101 @@ using namespace attr;
 namespace hesiod
 {
 
+// -----------------------------------------------------------------------------
+// Ports & Attributes
+// -----------------------------------------------------------------------------
+
+constexpr const char *P_DR = "dr";
+constexpr const char *P_ENV = "envelope";
+constexpr const char *P_OUT = "output";
+
+constexpr const char *A_KW = "kw";
+constexpr const char *A_ANGLE = "angle";
+constexpr const char *A_PHASE_SHIFT = "phase_shift";
+
+// -----------------------------------------------------------------------------
+// Setup
+// -----------------------------------------------------------------------------
+
 void setup_wave_sine_node(BaseNode &node)
 {
   Logger::log()->trace("setup node {}", node.get_label());
 
-  // port(s)
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "dr");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "envelope");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, "output", CONFIG(node));
+  // --- Ports
 
-  // attribute(s)
-  node.add_attr<FloatAttribute>("kw", "kw", 2.f, 0.01f, FLT_MAX);
-  node.add_attr<FloatAttribute>("angle", "angle", 0.f, -180.f, 180.f);
-  node.add_attr<FloatAttribute>("phase_shift", "phase_shift", 0.f, -180.f, 180.f);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_DR);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_ENV);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, P_OUT, CONFIG(node));
 
-  // attribute(s) order
-  node.set_attr_ordered_key({"kw", "angle", "phase_shift"});
+  // --- Attributes
+
+  node.add_attr<FloatAttribute>(A_KW, "kw", 2.f, 0.01f, FLT_MAX);
+  node.add_attr<FloatAttribute>(A_ANGLE, "angle", 0.f, -180.f, 180.f, "{:.1f}°");
+  node.add_attr<FloatAttribute>(A_PHASE_SHIFT,
+                                "phase_shift",
+                                0.f,
+                                -180.f,
+                                180.f,
+                                "{:.1f}°");
+
+  // --- Attribute(s) order
+
+  node.set_attr_ordered_key({
+      "_GROUPBOX_BEGIN_Wave Parameters",
+      A_KW,
+      A_ANGLE,
+      A_PHASE_SHIFT,
+      "_GROUPBOX_END_",
+  });
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = true, .remap_active_state = true});
 }
 
+// -----------------------------------------------------------------------------
+// Compute
+// -----------------------------------------------------------------------------
+
 void compute_wave_sine_node(BaseNode &node)
 {
   Logger::log()->trace("computing node [{}]/[{}]", node.get_label(), node.get_id());
 
-  // base noise function
-  hmap::VirtualArray *p_dr = node.get_value_ref<hmap::VirtualArray>("dr");
-  hmap::VirtualArray *p_env = node.get_value_ref<hmap::VirtualArray>("envelope");
-  hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>("output");
+  // --- Inputs / Outputs
+
+  auto *p_dr = node.get_value_ref<hmap::VirtualArray>(P_DR);
+  auto *p_env = node.get_value_ref<hmap::VirtualArray>(P_ENV);
+  auto *p_out = node.get_value_ref<hmap::VirtualArray>(P_OUT);
+
+  if (!p_out)
+    return;
+
+  // --- Params
+
+  // clang-format off
+  const auto kw          = node.get_attr<FloatAttribute>(A_KW);
+  const auto angle       = node.get_attr<FloatAttribute>(A_ANGLE);
+  const auto phase_shift = node.get_attr<FloatAttribute>(A_PHASE_SHIFT);
+  // clang-format on
+
+  // phase_shift slider is in degrees (range -180..180, matching `angle`);
+  // hmap::wave_sine expects radians in cos(2*pi*r + phase). Convert here.
+  const float phase_rad = phase_shift * float(M_PI / 180.0);
+
+  // --- Compute
 
   hmap::for_each_tile(
-      {p_out, p_dr},
-      [&node](std::vector<hmap::Array *> p_arrays, const hmap::TileRegion &region)
+      {p_dr},
+      {p_out},
+      [&](std::vector<const hmap::Array *> in,
+          std::vector<hmap::Array *>       out,
+          const hmap::TileRegion          &region)
       {
-        hmap::Array *pa_out = p_arrays[0];
-        hmap::Array *pa_dr = p_arrays[1];
-
-        // phase_shift slider is in degrees (range -180..180, matching `angle`);
-        // hmap::wave_sine expects radians in cos(2*pi*r + phase). Convert here.
-        const float phase_rad = node.get_attr<FloatAttribute>("phase_shift") *
-                                (float)(M_PI / 180.0);
+        auto [pa_dr] = unpack<1>(in);
+        auto [pa_out] = unpack<1>(out);
 
         *pa_out = hmap::wave_sine(region.shape,
-                                  node.get_attr<FloatAttribute>("kw"),
-                                  node.get_attr<FloatAttribute>("angle"),
+                                  kw,
+                                  angle,
                                   phase_rad,
                                   pa_dr,
                                   nullptr,
@@ -67,7 +117,8 @@ void compute_wave_sine_node(BaseNode &node)
       },
       node.cfg().cm_cpu);
 
-  // post-process
+  // --- Post-process
+
   post_apply_enveloppe(node, *p_out, p_env);
   post_process_heightmap(node, *p_out);
 }


### PR DESCRIPTION
## Summary
- **WaveSine:** `phase_shift` was passed to `hmap::wave_sine` as radians, but the slider is `-180..180` (degrees, matching the sibling `angle` param which is converted in `set_angle`). Now converted deg→rad in the wrapper.
- **SetBorders:** expose per-edge buffer radius (`unique_border_radius` + `radius_{west,east,north,south}`); fix the north/south *value* swap; fix N/S buffer thickness on non-square maps (now scales by map height, not width).
- **HydraulicParticle:** warn when the input is flat/near-constant — erosion is gradient-driven and otherwise no-ops silently on flat/masked-to-zero input.
- **node_documentation.json:** document coordinate conventions (`center.y` measured from the bottom; `radius` in domain units → elliptical on non-square maps; angles in degrees) for the geometric primitives, plus the WaveSine phase convention, the HydraulicParticle footgun, and the new SetBorders params.

## Behaviour changes (worth noting for existing graphs)
1. **WaveSine `phase_shift`** now means degrees — existing `.hsd` with a non-zero `phase_shift` will render differently (but correctly).
2. **SetBorders north/south values were swapped** in the old wrapper (`border_values.z`/`.w` mapped to the wrong edges vs the engine) — now corrected.
3. **SetBorders N/S buffer thickness now scales by map height** (E/W by width) — changes results on non-square maps, where the old `radius * shape.x` for all edges made N/S caps unusably thick.

## Test plan
Built (Release, g++/Qt6/OpenCL) and verified headless via `--batch`:
- WaveSine `phase=0` vs `phase=180` → exact inversion (`value_180 = 1 − value_0`, i.e. `cos(θ+π)`).
- HydraulicParticle on a flat `Constant` input → the new warning fires; non-flat input → no warning.
- SetBorders on square and 2:1 maps → `value_north` lands on the north (top) edge (no swap), per-edge radii apply, and N/S bands scale by height leaving a clean interior (the old width-scaling would overlap them).
