### PR TITLE
feat(wave): expose center attribute on wave nodes

### DIFF
--- a/Hesiod/data/node_documentation.json
+++ b/Hesiod/data/node_documentation.json
@@ -23000,6 +23000,12 @@
                 "label": "angle",
                 "type": "Float"
             },
+            "center": {
+                "description": "Reference center for the wave pattern within the heightmap.",
+                "key": "center",
+                "label": "center",
+                "type": "Vec2Float"
+            },
             "kw": {
                 "description": "Base spatial frequencies in the X and Y directions. The frequencies are defined with respect to the entire domain: for example, kw = 2 produces two full oscillations across the domain width (and similarly for the Y direction).",
                 "key": "kw",
@@ -23105,6 +23111,12 @@
                 "label": "angle",
                 "type": "Float"
             },
+            "center": {
+                "description": "Reference center for the wave pattern within the heightmap.",
+                "key": "center",
+                "label": "center",
+                "type": "Vec2Float"
+            },
             "kw": {
                 "description": "Base spatial frequencies in the X and Y directions. The frequencies are defined with respect to the entire domain: for example, kw = 2 produces two full oscillations across the domain width (and similarly for the Y direction). Wavenumber in cycles across the unit domain (applied to both X and Y).",
                 "key": "kw",
@@ -23198,6 +23210,12 @@
                 "label": "angle",
                 "type": "Float"
             },
+            "center": {
+                "description": "Reference center for the wave pattern within the heightmap.",
+                "key": "center",
+                "label": "center",
+                "type": "Vec2Float"
+            },
             "kw": {
                 "description": "Base spatial frequencies in the X and Y directions. The frequencies are defined with respect to the entire domain: for example, kw = 2 produces two full oscillations across the domain width (and similarly for the Y direction).",
                 "key": "kw",
@@ -23290,6 +23308,12 @@
                 "key": "angle",
                 "label": "angle",
                 "type": "Float"
+            },
+            "center": {
+                "description": "Reference center for the wave pattern within the heightmap.",
+                "key": "center",
+                "label": "center",
+                "type": "Vec2Float"
             },
             "kw": {
                 "description": "Base spatial frequencies in the X and Y directions. The frequencies are defined with respect to the entire domain: for example, kw = 2 produces two full oscillations across the domain width (and similarly for the Y direction).",

--- a/Hesiod/src/model/nodes/nodes_function/wave_dune.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/wave_dune.cpp
@@ -25,15 +25,19 @@ void setup_wave_dune_node(BaseNode &node)
 
   // attribute(s)
   node.add_attr<FloatAttribute>("kw", "kw", 2.f, 0.01f, FLT_MAX);
-  node.add_attr<FloatAttribute>("angle", "angle", 0.f, -180.f, 180.f);
+  node.add_attr<FloatAttribute>("angle", "angle", 0.f, -180.f, 180.f, "{:.1f}°");
   node.add_attr<FloatAttribute>("xtop", "xtop", 0.7f, 0.f, 1.f);
   node.add_attr<FloatAttribute>("xbottom", "xbottom", 0.9f, 0.f, 1.f);
-  node.add_attr<FloatAttribute>("phase_shift", "phase_shift", 0.f, -180.f, 180.f);
+  node.add_attr<FloatAttribute>("phase_shift",
+                                "phase_shift",
+                                0.f,
+                                -180.f,
+                                180.f,
+                                "{:.1f}°");
   node.add_attr<Vec2FloatAttribute>("center", "center");
 
   // attribute(s) order
-  node.set_attr_ordered_key(
-      {"kw", "angle", "xtop", "xbottom", "phase_shift", "center"});
+  node.set_attr_ordered_key({"kw", "angle", "xtop", "xbottom", "phase_shift", "center"});
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = true, .remap_active_state = true});
@@ -48,9 +52,12 @@ void compute_wave_dune_node(BaseNode &node)
   hmap::VirtualArray *p_env = node.get_value_ref<hmap::VirtualArray>("envelope");
   hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>("output");
 
+  const float phase_rad = node.get_attr<FloatAttribute>("phase_shift") *
+                          float(M_PI / 180.0);
+
   hmap::for_each_tile(
       {p_out, p_dr},
-      [&node](std::vector<hmap::Array *> p_arrays, const hmap::TileRegion &region)
+      [&](std::vector<hmap::Array *> p_arrays, const hmap::TileRegion &region)
       {
         hmap::Array *pa_out = p_arrays[0];
         hmap::Array *pa_dr = p_arrays[1];
@@ -60,7 +67,7 @@ void compute_wave_dune_node(BaseNode &node)
                                   node.get_attr<FloatAttribute>("angle"),
                                   node.get_attr<FloatAttribute>("xtop"),
                                   node.get_attr<FloatAttribute>("xbottom"),
-                                  node.get_attr<FloatAttribute>("phase_shift"),
+                                  phase_rad,
                                   pa_dr,
                                   nullptr,
                                   nullptr,

--- a/Hesiod/src/model/nodes/nodes_function/wave_dune.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/wave_dune.cpp
@@ -29,9 +29,11 @@ void setup_wave_dune_node(BaseNode &node)
   node.add_attr<FloatAttribute>("xtop", "xtop", 0.7f, 0.f, 1.f);
   node.add_attr<FloatAttribute>("xbottom", "xbottom", 0.9f, 0.f, 1.f);
   node.add_attr<FloatAttribute>("phase_shift", "phase_shift", 0.f, -180.f, 180.f);
+  node.add_attr<Vec2FloatAttribute>("center", "center");
 
   // attribute(s) order
-  node.set_attr_ordered_key({"kw", "angle", "xtop", "xbottom", "phase_shift"});
+  node.set_attr_ordered_key(
+      {"kw", "angle", "xtop", "xbottom", "phase_shift", "center"});
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = true, .remap_active_state = true});
@@ -62,6 +64,7 @@ void compute_wave_dune_node(BaseNode &node)
                                   pa_dr,
                                   nullptr,
                                   nullptr,
+                                  node.get_attr<Vec2FloatAttribute>("center"),
                                   region.bbox);
       },
       node.cfg().cm_cpu);

--- a/Hesiod/src/model/nodes/nodes_function/wave_sine.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/wave_sine.cpp
@@ -25,6 +25,7 @@ constexpr const char *P_OUT = "output";
 constexpr const char *A_KW = "kw";
 constexpr const char *A_ANGLE = "angle";
 constexpr const char *A_PHASE_SHIFT = "phase_shift";
+constexpr const char *A_CENTER = "center";
 
 // -----------------------------------------------------------------------------
 // Setup
@@ -50,6 +51,7 @@ void setup_wave_sine_node(BaseNode &node)
                                 -180.f,
                                 180.f,
                                 "{:.1f}°");
+  node.add_attr<Vec2FloatAttribute>(A_CENTER, "center");
 
   // --- Attribute(s) order
 
@@ -58,6 +60,7 @@ void setup_wave_sine_node(BaseNode &node)
       A_KW,
       A_ANGLE,
       A_PHASE_SHIFT,
+      A_CENTER,
       "_GROUPBOX_END_",
   });
 
@@ -88,6 +91,7 @@ void compute_wave_sine_node(BaseNode &node)
   const auto kw          = node.get_attr<FloatAttribute>(A_KW);
   const auto angle       = node.get_attr<FloatAttribute>(A_ANGLE);
   const auto phase_shift = node.get_attr<FloatAttribute>(A_PHASE_SHIFT);
+  const auto center      = node.get_attr<Vec2FloatAttribute>(A_CENTER);
   // clang-format on
 
   // phase_shift slider is in degrees (range -180..180, matching `angle`);
@@ -113,6 +117,7 @@ void compute_wave_sine_node(BaseNode &node)
                                   pa_dr,
                                   nullptr,
                                   nullptr,
+                                  center,
                                   region.bbox);
       },
       node.cfg().cm_cpu);

--- a/Hesiod/src/model/nodes/nodes_function/wave_square.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/wave_square.cpp
@@ -27,9 +27,10 @@ void setup_wave_square_node(BaseNode &node)
   node.add_attr<FloatAttribute>("kw", "kw", 2.f, 0.01f, FLT_MAX);
   node.add_attr<FloatAttribute>("angle", "angle", 0.f, 0.f, 180.f);
   node.add_attr<FloatAttribute>("phase_shift", "phase_shift", 0.f, -1.f, 1.f);
+  node.add_attr<Vec2FloatAttribute>("center", "center");
 
   // attribute(s) order
-  node.set_attr_ordered_key({"kw", "angle", "phase_shift"});
+  node.set_attr_ordered_key({"kw", "angle", "phase_shift", "center"});
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = true, .remap_active_state = true});
@@ -58,6 +59,7 @@ void compute_wave_square_node(BaseNode &node)
                                     pa_dr,
                                     nullptr,
                                     nullptr,
+                                    node.get_attr<Vec2FloatAttribute>("center"),
                                     region.bbox);
       },
       node.cfg().cm_cpu);

--- a/Hesiod/src/model/nodes/nodes_function/wave_square.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/wave_square.cpp
@@ -25,8 +25,13 @@ void setup_wave_square_node(BaseNode &node)
 
   // attribute(s)
   node.add_attr<FloatAttribute>("kw", "kw", 2.f, 0.01f, FLT_MAX);
-  node.add_attr<FloatAttribute>("angle", "angle", 0.f, 0.f, 180.f);
-  node.add_attr<FloatAttribute>("phase_shift", "phase_shift", 0.f, -1.f, 1.f);
+  node.add_attr<FloatAttribute>("angle", "angle", 0.f, 0.f, 180.f, "{:.1f}°");
+  node.add_attr<FloatAttribute>("phase_shift",
+                                "phase_shift",
+                                0.f,
+                                -180.f,
+                                180.f,
+                                "{:.1f}°");
   node.add_attr<Vec2FloatAttribute>("center", "center");
 
   // attribute(s) order
@@ -45,9 +50,12 @@ void compute_wave_square_node(BaseNode &node)
   hmap::VirtualArray *p_env = node.get_value_ref<hmap::VirtualArray>("envelope");
   hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>("output");
 
+  const float phase_rad = node.get_attr<FloatAttribute>("phase_shift") *
+                          float(M_PI / 180.0);
+
   hmap::for_each_tile(
       {p_out, p_dr},
-      [&node](std::vector<hmap::Array *> p_arrays, const hmap::TileRegion &region)
+      [&](std::vector<hmap::Array *> p_arrays, const hmap::TileRegion &region)
       {
         hmap::Array *pa_out = p_arrays[0];
         hmap::Array *pa_dr = p_arrays[1];
@@ -55,7 +63,7 @@ void compute_wave_square_node(BaseNode &node)
         *pa_out = hmap::wave_square(region.shape,
                                     node.get_attr<FloatAttribute>("kw"),
                                     node.get_attr<FloatAttribute>("angle"),
-                                    node.get_attr<FloatAttribute>("phase_shift"),
+                                    phase_rad,
                                     pa_dr,
                                     nullptr,
                                     nullptr,

--- a/Hesiod/src/model/nodes/nodes_function/wave_triangular.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/wave_triangular.cpp
@@ -28,9 +28,10 @@ void setup_wave_triangular_node(BaseNode &node)
   node.add_attr<FloatAttribute>("angle", "angle", 0.f, 0.f, 180.f);
   node.add_attr<FloatAttribute>("slant_ratio", "slant_ratio", 0.2f, 0.f, 1.f);
   node.add_attr<FloatAttribute>("phase_shift", "phase_shift", 0.f, -1.f, 1.f);
+  node.add_attr<Vec2FloatAttribute>("center", "center");
 
   // attribute(s) order
-  node.set_attr_ordered_key({"kw", "angle", "slant_ratio", "phase_shift"});
+  node.set_attr_ordered_key({"kw", "angle", "slant_ratio", "phase_shift", "center"});
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = true, .remap_active_state = true});
@@ -60,6 +61,7 @@ void compute_wave_triangular_node(BaseNode &node)
                                         pa_dr,
                                         nullptr,
                                         nullptr,
+                                        node.get_attr<Vec2FloatAttribute>("center"),
                                         region.bbox);
       },
       node.cfg().cm_cpu);

--- a/Hesiod/src/model/nodes/nodes_function/wave_triangular.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/wave_triangular.cpp
@@ -25,9 +25,14 @@ void setup_wave_triangular_node(BaseNode &node)
 
   // attribute(s)
   node.add_attr<FloatAttribute>("kw", "kw", 2.f, 0.01f, FLT_MAX);
-  node.add_attr<FloatAttribute>("angle", "angle", 0.f, 0.f, 180.f);
+  node.add_attr<FloatAttribute>("angle", "angle", 0.f, 0.f, 180.f, "{:.1f}°");
   node.add_attr<FloatAttribute>("slant_ratio", "slant_ratio", 0.2f, 0.f, 1.f);
-  node.add_attr<FloatAttribute>("phase_shift", "phase_shift", 0.f, -1.f, 1.f);
+  node.add_attr<FloatAttribute>("phase_shift",
+                                "phase_shift",
+                                0.f,
+                                -180.f,
+                                180.f,
+                                "{:.1f}°");
   node.add_attr<Vec2FloatAttribute>("center", "center");
 
   // attribute(s) order
@@ -46,9 +51,12 @@ void compute_wave_triangular_node(BaseNode &node)
   hmap::VirtualArray *p_env = node.get_value_ref<hmap::VirtualArray>("envelope");
   hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>("output");
 
+  const float phase_rad = node.get_attr<FloatAttribute>("phase_shift") *
+                          float(M_PI / 180.0);
+
   hmap::for_each_tile(
       {p_out, p_dr},
-      [&node](std::vector<hmap::Array *> p_arrays, const hmap::TileRegion &region)
+      [&](std::vector<hmap::Array *> p_arrays, const hmap::TileRegion &region)
       {
         hmap::Array *pa_out = p_arrays[0];
         hmap::Array *pa_dr = p_arrays[1];
@@ -57,7 +65,7 @@ void compute_wave_triangular_node(BaseNode &node)
                                         node.get_attr<FloatAttribute>("kw"),
                                         node.get_attr<FloatAttribute>("angle"),
                                         node.get_attr<FloatAttribute>("slant_ratio"),
-                                        node.get_attr<FloatAttribute>("phase_shift"),
+                                        phase_rad,
                                         pa_dr,
                                         nullptr,
                                         nullptr,


### PR DESCRIPTION
Adds a Vec2Float `center` attribute (default `{0.5, 0.5}`) to the **WaveSine**, **WaveSquare**, **WaveTriangular** and **WaveDune** nodes, mirroring the Slope node. It passes through to `hmap::wave_*` so the wave pattern can be anchored about the domain centre (e.g. symmetric latitude bands) instead of the origin. Documented in `node_documentation.json`.

> ⚠️ **Depends on otto-link/HighMap#387** (the matching `center` parameter on the wave primitives). Draft until that merges and the HighMap submodule is bumped. Runtime-verified locally against that branch.