### PR TITLE
feat(noise): add periodic (tileable) toggle to Noise and NoiseFbm

### DIFF
--- a/Hesiod/data/node_documentation.json
+++ b/Hesiod/data/node_documentation.json
@@ -11803,6 +11803,12 @@
                 "label": "Type",
                 "type": "Enumeration"
             },
+            "periodic": {
+                "description": "When enabled the noise is made tileable: the lattice is wrapped at a period derived from kw, and kw is snapped to integer cells so the wrap aligns with the noise frequency. Applies to lattice noise types only (no effect on Simplex); seamless fbm tiling additionally requires an integer lacunarity (the default 2).",
+                "key": "periodic",
+                "label": "periodic",
+                "type": "Bool"
+            },
             "post_gain": {
                 "description": "Mid-centered gain transformation applied to the elevation values. This is a non-linear recurve operator centered around the mid elevation (typically 0.5). Increasing the gain pushes values toward the minimum and maximum elevations, creating flatter low/high regions with a steeper transition around the midpoint.",
                 "key": "post_gain",
@@ -11901,6 +11907,12 @@
                 "key": "octaves",
                 "label": "Octaves",
                 "type": "Integer"
+            },
+            "periodic": {
+                "description": "When enabled the noise is made tileable: the lattice is wrapped at a period derived from kw, and kw is snapped to integer cells so the wrap aligns with the noise frequency. Applies to lattice noise types only (no effect on Simplex); seamless fbm tiling additionally requires an integer lacunarity (the default 2).",
+                "key": "periodic",
+                "label": "periodic",
+                "type": "Bool"
             },
             "persistence": {
                 "description": "The amplitude scaling factor for subsequent noise octaves. Lower values reduce the contribution of higher octaves.",

--- a/Hesiod/src/model/nodes/nodes_function/noise.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/noise.cpp
@@ -31,9 +31,11 @@ void setup_noise_node(BaseNode &node)
   node.add_attr<EnumAttribute>("noise_type", "Type", enum_mappings.noise_type_map);
   node.add_attr<WaveNbAttribute>("kw", "Spatial Frequency");
   node.add_attr<SeedAttribute>("seed", "Seed");
+  node.add_attr<BoolAttribute>("periodic", "Periodic (tileable)", false);
 
   // attribute(s) order
-  node.set_attr_ordered_key({"noise_type", "_SEPARATOR_", "kw", "seed"});
+  node.set_attr_ordered_key(
+      {"noise_type", "_SEPARATOR_", "kw", "seed", "periodic"});
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = false, .remap_active_state = true});
@@ -55,15 +57,26 @@ void compute_noise_node(BaseNode &node)
       {
         auto [pa_out, pa_dx, pa_dy] = unpack<3>(p_arrays);
 
+        // when periodic, snap kw to integer cells so the lattice wrap (period)
+        // aligns with the noise frequency and the result tiles seamlessly
+        glm::vec2  kw = node.get_attr<WaveNbAttribute>("kw");
+        glm::ivec2 period(-1, -1);
+        if (node.get_attr<BoolAttribute>("periodic"))
+        {
+          kw = glm::vec2((float)(int)(kw.x + 0.5f), (float)(int)(kw.y + 0.5f));
+          period = glm::ivec2((int)kw.x, (int)kw.y);
+        }
+
         *pa_out = hmap::gpu::noise(
             (hmap::NoiseType)node.get_attr<EnumAttribute>("noise_type"),
             region.shape,
-            node.get_attr<WaveNbAttribute>("kw"),
+            kw,
             node.get_attr<SeedAttribute>("seed"),
             pa_dx,
             pa_dy,
             nullptr,
-            region.bbox);
+            region.bbox,
+            period);
       },
       node.cfg().cm_gpu);
 

--- a/Hesiod/src/model/nodes/nodes_function/noise.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/noise.cpp
@@ -17,70 +17,130 @@ using namespace attr;
 namespace hesiod
 {
 
+// -----------------------------------------------------------------------------
+// Ports & Attributes
+// -----------------------------------------------------------------------------
+
+constexpr const char *P_DX = "dx";
+constexpr const char *P_DY = "dy";
+constexpr const char *P_ENV = "envelope";
+constexpr const char *P_OUT = "out";
+
+constexpr const char *A_NOISE_TYPE = "noise_type";
+constexpr const char *A_KW = "kw";
+constexpr const char *A_SEED = "seed";
+constexpr const char *A_PERIODIC = "periodic";
+
+// -----------------------------------------------------------------------------
+// Setup
+// -----------------------------------------------------------------------------
+
 void setup_noise_node(BaseNode &node)
 {
   Logger::log()->trace("setup node {}", node.get_label());
 
-  // port(s)
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "dx");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "dy");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "envelope");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, "out", CONFIG(node));
+  // --- Ports
 
-  // attribute(s)
-  node.add_attr<EnumAttribute>("noise_type", "Type", enum_mappings.noise_type_map);
-  node.add_attr<WaveNbAttribute>("kw", "Spatial Frequency");
-  node.add_attr<SeedAttribute>("seed", "Seed");
-  node.add_attr<BoolAttribute>("periodic", "Periodic (tileable)", false);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_DX);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_DY);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_ENV);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, P_OUT, CONFIG(node));
 
-  // attribute(s) order
-  node.set_attr_ordered_key(
-      {"noise_type", "_SEPARATOR_", "kw", "seed", "periodic"});
+  // --- Attributes
+
+  // clang-format off
+  node.add_attr<EnumAttribute>(A_NOISE_TYPE, "Type", enum_mappings.noise_type_map);
+  node.add_attr<WaveNbAttribute>(A_KW, "Spatial Frequency");
+  node.add_attr<SeedAttribute>(A_SEED, "Seed");
+  node.add_attr<BoolAttribute>(A_PERIODIC, "Periodic (tileable)", false);
+  // clang-format on
+
+  // --- Attribute(s) order
+
+  node.set_attr_ordered_key({
+      "_GROUPBOX_BEGIN_Main Parameters",
+      A_NOISE_TYPE,
+      A_KW,
+      A_SEED,
+      "_GROUPBOX_END_",
+      //
+      "_GROUPBOX_BEGIN_Tiling",
+      A_PERIODIC,
+      "_GROUPBOX_END_",
+  });
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = false, .remap_active_state = true});
 }
 
+// -----------------------------------------------------------------------------
+// Compute
+// -----------------------------------------------------------------------------
+
 void compute_noise_node(BaseNode &node)
 {
   Logger::log()->trace("computing node [{}]/[{}]", node.get_label(), node.get_id());
 
-  // base noise function
-  hmap::VirtualArray *p_dx = node.get_value_ref<hmap::VirtualArray>("dx");
-  hmap::VirtualArray *p_dy = node.get_value_ref<hmap::VirtualArray>("dy");
-  hmap::VirtualArray *p_env = node.get_value_ref<hmap::VirtualArray>("envelope");
-  hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>("out");
+  // --- Inputs / Outputs
+
+  auto *p_dx = node.get_value_ref<hmap::VirtualArray>(P_DX);
+  auto *p_dy = node.get_value_ref<hmap::VirtualArray>(P_DY);
+  auto *p_env = node.get_value_ref<hmap::VirtualArray>(P_ENV);
+  auto *p_out = node.get_value_ref<hmap::VirtualArray>(P_OUT);
+
+  if (!p_out)
+    return;
+
+  // --- Params
+
+  // clang-format off
+  const auto noise_type = hmap::NoiseType(node.get_attr<EnumAttribute>(A_NOISE_TYPE));
+  const auto kw         = node.get_attr<WaveNbAttribute>(A_KW);
+  const auto seed       = node.get_attr<SeedAttribute>(A_SEED);
+  const auto periodic   = node.get_attr<BoolAttribute>(A_PERIODIC);
+  // clang-format on
+
+  // --- Compute
 
   hmap::for_each_tile(
-      {p_out, p_dx, p_dy},
-      [&node](std::vector<hmap::Array *> p_arrays, const hmap::TileRegion &region)
+      {p_dx, p_dy},
+      {p_out},
+      [&](std::vector<const hmap::Array *> in,
+          std::vector<hmap::Array *>       out,
+          const hmap::TileRegion          &region)
       {
-        auto [pa_out, pa_dx, pa_dy] = unpack<3>(p_arrays);
+        auto [pa_dx, pa_dy] = unpack<2>(in);
+        auto [pa_out] = unpack<1>(out);
 
-        // when periodic, snap kw to integer cells so the lattice wrap (period)
-        // aligns with the noise frequency and the result tiles seamlessly
-        glm::vec2  kw = node.get_attr<WaveNbAttribute>("kw");
-        glm::ivec2 period(-1, -1);
-        if (node.get_attr<BoolAttribute>("periodic"))
+        // When periodic, snap kw to integer cells so the lattice wrap
+        // aligns with the noise frequency and the result tiles
+        // seamlessly.
+
+        glm::vec2  kw_local = kw;
+        glm::ivec2 period(0, 0);
+
+        if (periodic)
         {
-          kw = glm::vec2((float)(int)(kw.x + 0.5f), (float)(int)(kw.y + 0.5f));
-          period = glm::ivec2((int)kw.x, (int)kw.y);
+          kw_local = glm::vec2(float(int(kw_local.x + 0.5f)),
+                               float(int(kw_local.y + 0.5f)));
+
+          period = glm::ivec2(int(kw_local.x), int(kw_local.y));
         }
 
-        *pa_out = hmap::gpu::noise(
-            (hmap::NoiseType)node.get_attr<EnumAttribute>("noise_type"),
-            region.shape,
-            kw,
-            node.get_attr<SeedAttribute>("seed"),
-            pa_dx,
-            pa_dy,
-            nullptr,
-            region.bbox,
-            period);
+        *pa_out = hmap::gpu::noise(noise_type,
+                                   region.shape,
+                                   kw_local,
+                                   seed,
+                                   pa_dx,
+                                   pa_dy,
+                                   nullptr,
+                                   region.bbox,
+                                   period);
       },
       node.cfg().cm_gpu);
 
-  // post-process
+  // --- Post-process
+
   post_apply_enveloppe(node, *p_out, p_env);
   post_process_heightmap(node, *p_out);
 }

--- a/Hesiod/src/model/nodes/nodes_function/noise_fbm.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/noise_fbm.cpp
@@ -16,87 +16,157 @@ using namespace attr;
 namespace hesiod
 {
 
+// -----------------------------------------------------------------------------
+// Ports & Attributes
+// -----------------------------------------------------------------------------
+
+constexpr const char *P_DX = "dx";
+constexpr const char *P_DY = "dy";
+constexpr const char *P_CTRL = "control";
+constexpr const char *P_ENV = "envelope";
+constexpr const char *P_OUT = "output";
+
+constexpr const char *A_NOISE_TYPE = "noise_type";
+constexpr const char *A_KW = "kw";
+constexpr const char *A_SEED = "seed";
+constexpr const char *A_OCTAVES = "octaves";
+constexpr const char *A_WEIGHT = "weight";
+constexpr const char *A_PERSISTENCE = "persistence";
+constexpr const char *A_LACUNARITY = "lacunarity";
+constexpr const char *A_PERIODIC = "periodic";
+
+// -----------------------------------------------------------------------------
+// Setup
+// -----------------------------------------------------------------------------
+
 void setup_noise_fbm_node(BaseNode &node)
 {
   Logger::log()->trace("setup node {}", node.get_label());
 
-  // port(s)
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "dx");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "dy");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "control");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "envelope");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, "output", CONFIG(node));
+  // --- Ports
 
-  // attribute(s)
-  node.add_attr<EnumAttribute>("noise_type", "Type", enum_mappings.noise_type_map_fbm);
-  node.add_attr<WaveNbAttribute>("kw", "Spatial Frequency");
-  node.add_attr<SeedAttribute>("seed", "Seed");
-  node.add_attr<IntAttribute>("octaves", "Octaves", 8, 0, 32);
-  node.add_attr<FloatAttribute>("weight", "Weight", 0.7f, 0.f, 1.f);
-  node.add_attr<FloatAttribute>("persistence", "Persistence", 0.5f, 0.f, 1.f);
-  node.add_attr<FloatAttribute>("lacunarity", "Lacunarity", 2.f, 0.01f, 4.f);
-  node.add_attr<BoolAttribute>("periodic", "Periodic (tileable)", false);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_DX);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_DY);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_CTRL);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_ENV);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, P_OUT, CONFIG(node));
 
-  // attribute(s) order
-  node.set_attr_ordered_key({"noise_type",
-                             "kw",
-                             "seed",
-                             "octaves",
-                             "weight",
-                             "persistence",
-                             "lacunarity",
-                             "periodic"});
+  // --- Attributes
+
+  // clang-format off
+  node.add_attr<EnumAttribute>(A_NOISE_TYPE, "Type", enum_mappings.noise_type_map_fbm);
+  node.add_attr<WaveNbAttribute>(A_KW, "Spatial Frequency");
+  node.add_attr<SeedAttribute>(A_SEED, "Seed");
+  node.add_attr<IntAttribute>(A_OCTAVES, "Octaves", 8, 0, 32);
+  node.add_attr<FloatAttribute>(A_WEIGHT, "Weight", 0.7f, 0.f, 1.f);
+  node.add_attr<FloatAttribute>(A_PERSISTENCE, "Persistence", 0.5f, 0.f, 1.f);
+  node.add_attr<FloatAttribute>(A_LACUNARITY, "Lacunarity", 2.f, 0.01f, 4.f);
+  node.add_attr<BoolAttribute>(A_PERIODIC, "Periodic (tileable)", false);
+  // clang-format on
+
+  // --- Attribute(s) order
+
+  node.set_attr_ordered_key({
+      "_GROUPBOX_BEGIN_Main Parameters",
+      A_NOISE_TYPE,
+      A_KW,
+      A_SEED,
+      A_OCTAVES,
+      "_GROUPBOX_END_",
+      //
+      "_GROUPBOX_BEGIN_fBm layers",
+      A_WEIGHT,
+      A_PERSISTENCE,
+      A_LACUNARITY,
+      "_GROUPBOX_END_",
+      //
+      "_GROUPBOX_BEGIN_Tiling",
+      A_PERIODIC,
+      "_GROUPBOX_END_",
+  });
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = false, .remap_active_state = true});
 }
 
+// -----------------------------------------------------------------------------
+// Compute
+// -----------------------------------------------------------------------------
+
 void compute_noise_fbm_node(BaseNode &node)
 {
   Logger::log()->trace("computing node [{}]/[{}]", node.get_label(), node.get_id());
 
-  // base noise function
-  hmap::VirtualArray *p_dx = node.get_value_ref<hmap::VirtualArray>("dx");
-  hmap::VirtualArray *p_dy = node.get_value_ref<hmap::VirtualArray>("dy");
-  hmap::VirtualArray *p_ctrl = node.get_value_ref<hmap::VirtualArray>("control");
-  hmap::VirtualArray *p_env = node.get_value_ref<hmap::VirtualArray>("envelope");
-  hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>("output");
+  // --- Inputs / Outputs
+
+  auto *p_dx = node.get_value_ref<hmap::VirtualArray>(P_DX);
+  auto *p_dy = node.get_value_ref<hmap::VirtualArray>(P_DY);
+  auto *p_ctrl = node.get_value_ref<hmap::VirtualArray>(P_CTRL);
+  auto *p_env = node.get_value_ref<hmap::VirtualArray>(P_ENV);
+  auto *p_out = node.get_value_ref<hmap::VirtualArray>(P_OUT);
+
+  if (!p_out)
+    return;
+
+  // --- Params
+
+  // clang-format off
+  const auto noise_type  = hmap::NoiseType(node.get_attr<EnumAttribute>(A_NOISE_TYPE));
+  const auto kw          = node.get_attr<WaveNbAttribute>(A_KW);
+  const auto seed        = node.get_attr<SeedAttribute>(A_SEED);
+  const auto octaves     = node.get_attr<IntAttribute>(A_OCTAVES);
+  const auto weight      = node.get_attr<FloatAttribute>(A_WEIGHT);
+  const auto persistence = node.get_attr<FloatAttribute>(A_PERSISTENCE);
+  const auto lacunarity  = node.get_attr<FloatAttribute>(A_LACUNARITY);
+  const auto periodic    = node.get_attr<BoolAttribute>(A_PERIODIC);
+  // clang-format on
+
+  // --- Compute
 
   hmap::for_each_tile(
-      {p_out, p_dx, p_dy, p_ctrl},
-      [&node](std::vector<hmap::Array *> p_arrays, const hmap::TileRegion &region)
+      {p_dx, p_dy, p_ctrl},
+      {p_out},
+      [&](std::vector<const hmap::Array *> in,
+          std::vector<hmap::Array *>       out,
+          const hmap::TileRegion          &region)
       {
-        auto [pa_out, pa_dx, pa_dy, pa_ctrl] = unpack<4>(p_arrays);
+        auto [pa_dx, pa_dy, pa_ctrl] = unpack<3>(in);
+        auto [pa_out] = unpack<1>(out);
 
-        // when periodic, snap kw to integer cells so the lattice wrap (period)
-        // aligns with the noise frequency and the result tiles seamlessly
-        glm::vec2  kw = node.get_attr<WaveNbAttribute>("kw");
-        glm::ivec2 period(-1, -1);
-        if (node.get_attr<BoolAttribute>("periodic"))
+        // When periodic, snap kw to integer cells so the lattice wrap
+        // aligns with the noise frequency and the result tiles
+        // seamlessly.
+
+        glm::vec2  kw_local = kw;
+        glm::ivec2 period(0, 0);
+
+        if (periodic)
         {
-          kw = glm::vec2((float)(int)(kw.x + 0.5f), (float)(int)(kw.y + 0.5f));
-          period = glm::ivec2((int)kw.x, (int)kw.y);
+          kw_local = glm::vec2(float(int(kw_local.x + 0.5f)),
+                               float(int(kw_local.y + 0.5f)));
+
+          period = glm::ivec2(int(kw_local.x), int(kw_local.y));
         }
 
-        *pa_out = hmap::gpu::noise_fbm(
-            (hmap::NoiseType)node.get_attr<EnumAttribute>("noise_type"),
-            region.shape,
-            kw,
-            node.get_attr<SeedAttribute>("seed"),
-            node.get_attr<IntAttribute>("octaves"),
-            node.get_attr<FloatAttribute>("weight"),
-            node.get_attr<FloatAttribute>("persistence"),
-            node.get_attr<FloatAttribute>("lacunarity"),
-            pa_ctrl,
-            pa_dx,
-            pa_dy,
-            nullptr,
-            region.bbox,
-            period);
+        *pa_out = hmap::gpu::noise_fbm(noise_type,
+                                       region.shape,
+                                       kw_local,
+                                       seed,
+                                       octaves,
+                                       weight,
+                                       persistence,
+                                       lacunarity,
+                                       pa_ctrl,
+                                       pa_dx,
+                                       pa_dy,
+                                       nullptr,
+                                       region.bbox,
+                                       period);
       },
       node.cfg().cm_gpu);
 
-  // post-process
+  // --- Post-process
+
   post_apply_enveloppe(node, *p_out, p_env);
   post_process_heightmap(node, *p_out);
 }

--- a/Hesiod/src/model/nodes/nodes_function/noise_fbm.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/noise_fbm.cpp
@@ -35,10 +35,17 @@ void setup_noise_fbm_node(BaseNode &node)
   node.add_attr<FloatAttribute>("weight", "Weight", 0.7f, 0.f, 1.f);
   node.add_attr<FloatAttribute>("persistence", "Persistence", 0.5f, 0.f, 1.f);
   node.add_attr<FloatAttribute>("lacunarity", "Lacunarity", 2.f, 0.01f, 4.f);
+  node.add_attr<BoolAttribute>("periodic", "Periodic (tileable)", false);
 
   // attribute(s) order
-  node.set_attr_ordered_key(
-      {"noise_type", "kw", "seed", "octaves", "weight", "persistence", "lacunarity"});
+  node.set_attr_ordered_key({"noise_type",
+                             "kw",
+                             "seed",
+                             "octaves",
+                             "weight",
+                             "persistence",
+                             "lacunarity",
+                             "periodic"});
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = false, .remap_active_state = true});
@@ -61,10 +68,20 @@ void compute_noise_fbm_node(BaseNode &node)
       {
         auto [pa_out, pa_dx, pa_dy, pa_ctrl] = unpack<4>(p_arrays);
 
+        // when periodic, snap kw to integer cells so the lattice wrap (period)
+        // aligns with the noise frequency and the result tiles seamlessly
+        glm::vec2  kw = node.get_attr<WaveNbAttribute>("kw");
+        glm::ivec2 period(-1, -1);
+        if (node.get_attr<BoolAttribute>("periodic"))
+        {
+          kw = glm::vec2((float)(int)(kw.x + 0.5f), (float)(int)(kw.y + 0.5f));
+          period = glm::ivec2((int)kw.x, (int)kw.y);
+        }
+
         *pa_out = hmap::gpu::noise_fbm(
             (hmap::NoiseType)node.get_attr<EnumAttribute>("noise_type"),
             region.shape,
-            node.get_attr<WaveNbAttribute>("kw"),
+            kw,
             node.get_attr<SeedAttribute>("seed"),
             node.get_attr<IntAttribute>("octaves"),
             node.get_attr<FloatAttribute>("weight"),
@@ -74,7 +91,8 @@ void compute_noise_fbm_node(BaseNode &node)
             pa_dx,
             pa_dy,
             nullptr,
-            region.bbox);
+            region.bbox,
+            period);
       },
       node.cfg().cm_gpu);
 


### PR DESCRIPTION
Exposes a **Periodic (tileable)** bool on the **Noise** and **NoiseFbm** nodes. When enabled, `kw` is snapped to integer cells and a lattice period (`= round(kw)`) is passed to `hmap::gpu::noise` / `noise_fbm` so the output tiles seamlessly. Lattice noise types only (no effect on Simplex). Documented in `node_documentation.json`.

> ⚠️ **Depends on otto-link/HighMap#388** (the GPU `period` parameter). Draft until that merges and the HighMap submodule is bumped. Runtime-verified locally against that branch (OpenCL kernel builds on NVIDIA, output tiles).