### PR TITLE
fix(app): make headless --snapshot/--inventory work without crashing

### DIFF
--- a/Hesiod/include/hesiod/app/app_context.hpp
+++ b/Hesiod/include/hesiod/app/app_context.hpp
@@ -37,6 +37,10 @@ public:
   // --- Data
   void load_node_documentation();
 
+  // runtime flag: true in headless CLI modes (e.g. --snapshot) so GUI-only,
+  // window/OpenGL-dependent widgets (3D viewer) are skipped
+  bool headless = false;
+
   // global settings
   AppSettings    app_settings;
   StyleSettings  style_settings;

--- a/Hesiod/include/hesiod/app/app_context.hpp
+++ b/Hesiod/include/hesiod/app/app_context.hpp
@@ -29,6 +29,9 @@ public:
   void           save_settings() const;
   void           reset_settings();
 
+  void save_state() const;
+  void restore_state();
+
   // --- Project management
   void new_project();
   void load_project_model(const std::string &fname);
@@ -48,6 +51,9 @@ public:
 
   // project
   std::unique_ptr<ProjectModel> project_model;
+
+private:
+  mutable nlohmann::json saved_state;
 };
 
 // helpers

--- a/Hesiod/include/hesiod/app/hesiod_application.hpp
+++ b/Hesiod/include/hesiod/app/hesiod_application.hpp
@@ -77,9 +77,9 @@ private:
 
   // --- Members (respect order for deletion)
   AppContext                 context;
-  MainWindow                *main_window = nullptr;  // null in headless CLI modes
-  std::unique_ptr<ProjectUI> project_ui;          // because top-level UI
-  AppSettingsWindow         *app_settings_window; // owned by MainWindow
+  MainWindow                *main_window = nullptr; // null in headless CLI modes
+  std::unique_ptr<ProjectUI> project_ui;            // because top-level UI
+  AppSettingsWindow         *app_settings_window;   // owned by MainWindow
 
   BlenderStreamer blender_streamer;
 

--- a/Hesiod/include/hesiod/app/hesiod_application.hpp
+++ b/Hesiod/include/hesiod/app/hesiod_application.hpp
@@ -77,7 +77,7 @@ private:
 
   // --- Members (respect order for deletion)
   AppContext                 context;
-  MainWindow                *main_window;
+  MainWindow                *main_window = nullptr;  // null in headless CLI modes
   std::unique_ptr<ProjectUI> project_ui;          // because top-level UI
   AppSettingsWindow         *app_settings_window; // owned by MainWindow
 

--- a/Hesiod/src/app/app_context.cpp
+++ b/Hesiod/src/app/app_context.cpp
@@ -88,6 +88,22 @@ void AppContext::reset_settings()
   this->style_settings = StyleSettings();
 }
 
+void AppContext::restore_state()
+{
+  if (this->saved_state.is_null() || this->saved_state.empty())
+    return;
+
+  try
+  {
+    this->settings_json_from(this->saved_state);
+  }
+  catch (const std::exception &e)
+  {
+    Logger::log()->error("Failed to restore state: {}", e.what());
+    return;
+  }
+}
+
 void AppContext::save_project_model(const std::string &fname) const
 {
   Logger::log()->trace("AppContext::save_project_model: {}", fname);
@@ -95,6 +111,8 @@ void AppContext::save_project_model(const std::string &fname) const
   nlohmann::json json = this->project_model->json_to();
   json_to_file(json, fname, /* merge_with_existing_content */ true);
 }
+
+void AppContext::save_state() const { this->saved_state = this->settings_json_to(); }
 
 void AppContext::save_settings() const
 {

--- a/Hesiod/src/app/hesiod_application.cpp
+++ b/Hesiod/src/app/hesiod_application.cpp
@@ -182,10 +182,14 @@ void HesiodApplication::load_project_model_and_ui(const std::string &fname,
   // --- UI
 
   // remove first old central widget (if any) so it doesn't linger
-  if (QWidget *old = this->main_window->takeCentralWidget())
+  // (main_window is null in headless CLI modes: --snapshot / --inventory)
+  if (this->main_window)
   {
-    old->setParent(nullptr);
-    old->deleteLater();
+    if (QWidget *old = this->main_window->takeCentralWidget())
+    {
+      old->setParent(nullptr);
+      old->deleteLater();
+    }
   }
 
   this->project_ui = std::make_unique<ProjectUI>();
@@ -193,7 +197,8 @@ void HesiodApplication::load_project_model_and_ui(const std::string &fname,
   this->project_ui->initialize(this->context.project_model.get());
   this->project_ui->load_ui_state(actual_fname);
 
-  this->main_window->setCentralWidget(this->project_ui->get_widget());
+  if (this->main_window)
+    this->main_window->setCentralWidget(this->project_ui->get_widget());
 
   // reset other visibility state
   this->project_ui->get_graph_manager_widget_ref()->setVisible(
@@ -230,7 +235,8 @@ void HesiodApplication::load_project_model_and_ui(const std::string &fname,
   { this->on_project_name_changed(); };
 
   // Project model and UI -> MainWindow
-  this->main_window->setup_connections_with_project();
+  if (this->main_window)
+    this->main_window->setup_connections_with_project();
 
   // rename whether fname is empty or not
   if (keep_name)
@@ -242,7 +248,8 @@ void HesiodApplication::load_project_model_and_ui(const std::string &fname,
 void HesiodApplication::notify(const std::string &msg, int timeout)
 {
   Logger::log()->trace("HesiodApplication::notify: {}", msg);
-  this->main_window->notify(msg, timeout);
+  if (this->main_window)
+    this->main_window->notify(msg, timeout);
 }
 
 void HesiodApplication::on_application_settings_action()
@@ -460,7 +467,8 @@ void HesiodApplication::on_project_name_changed()
   if (this->context.project_model->get_is_dirty())
     title += "*";
 
-  this->main_window->setWindowTitle(title.c_str());
+  if (this->main_window)
+    this->main_window->setWindowTitle(title.c_str());
 }
 
 void HesiodApplication::on_project_settings()

--- a/Hesiod/src/cli/batch_mode.cpp
+++ b/Hesiod/src/cli/batch_mode.cpp
@@ -174,24 +174,19 @@ void run_snapshot_generation()
 
   auto *app = static_cast<hesiod::HesiodApplication *>(QCoreApplication::instance());
 
+  AppContext &ctx = app->get_context();
+  ctx.save_state();
+
   // headless: skip GUI-only / OpenGL widgets (3D viewer) when building the graph UI
-  app->get_context().headless = true;
+  ctx.headless = true;
 
   // strip everything but the node graph from the snapshot: deactivate the node
   // settings pan, the per-graph 3D viewer, the node library panel (so the graph
   // gets the full frame width), and the WebEngine texture downloader.
-  auto &ne = app->get_context().app_settings.node_editor;
-  auto &iface = app->get_context().app_settings.interface;
-
-  const bool bckp_snsp = ne.show_node_settings_pan;
-  const bool bckp_sw = ne.show_viewer;
-  const bool bckp_lib = ne.show_node_library_pan;
-  const bool bckp_txd = iface.enable_texture_downloader;
-
-  ne.show_node_settings_pan = false;
-  ne.show_viewer = false;
-  ne.show_node_library_pan = false;
-  iface.enable_texture_downloader = false;
+  ctx.app_settings.node_editor.show_node_settings_pan = false;
+  ctx.app_settings.node_editor.show_viewer = false;
+  ctx.app_settings.node_editor.show_node_library_pan = false;
+  ctx.app_settings.interface.enable_texture_downloader = false;
 
   for (auto &[node_type, _] : inventory)
   {
@@ -241,11 +236,7 @@ void run_snapshot_generation()
     }
   }
 
-  ne.show_node_settings_pan = bckp_snsp;
-  ne.show_viewer = bckp_sw;
-  ne.show_node_library_pan = bckp_lib;
-  iface.enable_texture_downloader = bckp_txd;
-  app->get_context().headless = false;
+  ctx.restore_state();
 }
 
 } // namespace hesiod::cli

--- a/Hesiod/src/cli/batch_mode.cpp
+++ b/Hesiod/src/cli/batch_mode.cpp
@@ -174,13 +174,24 @@ void run_snapshot_generation()
 
   auto *app = static_cast<hesiod::HesiodApplication *>(QCoreApplication::instance());
 
-  // deactivate viewport and node settings pan in graph viewer
-  const bool bckp_snsp = app->get_context()
-                             .app_settings.node_editor.show_node_settings_pan;
-  const bool bckp_sw = app->get_context().app_settings.node_editor.show_viewer;
+  // headless: skip GUI-only / OpenGL widgets (3D viewer) when building the graph UI
+  app->get_context().headless = true;
 
-  app->get_context().app_settings.node_editor.show_node_settings_pan = false;
-  app->get_context().app_settings.node_editor.show_viewer = false;
+  // strip everything but the node graph from the snapshot: deactivate the node
+  // settings pan, the per-graph 3D viewer, the node library panel (so the graph
+  // gets the full frame width), and the WebEngine texture downloader.
+  auto &ne = app->get_context().app_settings.node_editor;
+  auto &iface = app->get_context().app_settings.interface;
+
+  const bool bckp_snsp = ne.show_node_settings_pan;
+  const bool bckp_sw = ne.show_viewer;
+  const bool bckp_lib = ne.show_node_library_pan;
+  const bool bckp_txd = iface.enable_texture_downloader;
+
+  ne.show_node_settings_pan = false;
+  ne.show_viewer = false;
+  ne.show_node_library_pan = false;
+  iface.enable_texture_downloader = false;
 
   for (auto &[node_type, _] : inventory)
   {
@@ -190,36 +201,51 @@ void run_snapshot_generation()
     {
       Logger::log()->trace("- default file exists: {}", fname);
 
-      app->load_project_model_and_ui(fname);
-
-      GraphTabsWidget *p_gtw = app->get_project_ui_ref()->get_graph_tabs_widget_ref();
-
-      if (p_gtw)
+      // a single broken example (e.g. a stale port name in the .hsd) must not
+      // abort the whole batch: log and skip it
+      try
       {
-        p_gtw->zoom_to_content();
+        app->load_project_model_and_ui(fname);
 
-        // TODO refit again, not working...
-        auto post_render_callback = [&]() { return; };
+        GraphTabsWidget *p_gtw = app->get_project_ui_ref()->get_graph_tabs_widget_ref();
 
-        QWidget *widget = dynamic_cast<QWidget *>(p_gtw);
+        if (p_gtw)
+        {
+          QWidget *widget = dynamic_cast<QWidget *>(p_gtw);
 
-        render_widget_screenshot(widget,
-                                 node_type + "_hsd_example.png",
-                                 size,
-                                 post_render_callback);
+          // size the widget to the final render size FIRST, then fit the graph
+          // to it: zoom_to_content() must run against the actual 512x512
+          // viewport, otherwise the fit is computed at the pre-render size and
+          // the graph is cropped (the old "TODO refit" problem).
+          widget->setFixedSize(size);
+          QCoreApplication::processEvents();
+          p_gtw->zoom_to_content();
+          QCoreApplication::processEvents();
 
-        QCoreApplication::processEvents();
+          render_widget_screenshot(widget, node_type + "_hsd_example.png", size);
 
-        // to avoid Qt panicking...
-        QEventLoop loop;
-        QTimer::singleShot(50, &loop, &QEventLoop::quit);
-        loop.exec();
+          QCoreApplication::processEvents();
+
+          // to avoid Qt panicking...
+          QEventLoop loop;
+          QTimer::singleShot(50, &loop, &QEventLoop::quit);
+          loop.exec();
+        }
+      }
+      catch (const std::exception &e)
+      {
+        Logger::log()->error("snapshot generation failed for '{}', skipping: {}",
+                             fname,
+                             e.what());
       }
     }
   }
 
-  app->get_context().app_settings.node_editor.show_node_settings_pan = bckp_snsp;
-  app->get_context().app_settings.node_editor.show_viewer = bckp_sw;
+  ne.show_node_settings_pan = bckp_snsp;
+  ne.show_viewer = bckp_sw;
+  ne.show_node_library_pan = bckp_lib;
+  iface.enable_texture_downloader = bckp_txd;
+  app->get_context().headless = false;
 }
 
 } // namespace hesiod::cli

--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -143,10 +143,17 @@ void GraphEditorWidget::setup_layout()
     splitter->setChildrenCollapsible(false);
 
     this->graph_node_widget = new GraphNodeWidget(gno->get_shared());
-    this->viewer = new Viewer3D(this->graph_node_widget);
-    this->viewer->setMinimumHeight(32);
 
-    splitter->addWidget(this->viewer);
+    // skip the 3D viewer (OpenGL) in headless CLI modes (e.g. --snapshot): it
+    // would receive paint events and crash without a real GUI window context.
+    // get_viewer() stays null and every caller already null-guards it.
+    if (!HSD_CTX.headless)
+    {
+      this->viewer = new Viewer3D(this->graph_node_widget);
+      this->viewer->setMinimumHeight(32);
+      splitter->addWidget(this->viewer);
+    }
+
     splitter->addWidget(this->graph_node_widget);
 
     layout->addWidget(splitter, 0, row_offset);

--- a/Hesiod/src/gui/widgets/graph_node_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_node_widget.cpp
@@ -334,8 +334,9 @@ void GraphNodeWidget::json_from(nlohmann::json const &json)
   GraphViewer::json_from(json);
   this->set_block_graph_model_updates(false);
 
-  // viewers
-  if (json.contains("viewers") && json["viewers"].is_array())
+  // viewers (skipped in headless CLI modes, e.g. --snapshot: no 3D viewer is
+  // created there, so there is nothing to restore state into)
+  if (!HSD_CTX.headless && json.contains("viewers") && json["viewers"].is_array())
   {
     for (const auto &viewer_json : json["viewers"])
     {
@@ -1234,6 +1235,11 @@ void GraphNodeWidget::on_nodes_paste_request()
 void GraphNodeWidget::on_viewport_request()
 {
   Logger::log()->trace("GraphNodeWidget::on_viewport_request");
+
+  // no independent 3D viewer window in headless CLI modes (e.g. --snapshot):
+  // it would receive paint events and crash without a real GUI window context
+  if (HSD_CTX.headless)
+    return;
 
   auto gno = this->p_graph_node.lock();
   if (!gno)


### PR DESCRIPTION
## Summary

`hesiod --snapshot` (and `--inventory`) currently segfaults on the first example it loads, so the node-reference example images can't be regenerated headlessly. This fixes the headless CLI path so a full `--snapshot` run completes.

Root cause: CLI modes run inside `parse_args()`, which is called in the `HesiodApplication` constructor **before** the GUI (`main_window`) is created — but snapshot generation reuses the full interactive project-load path, which assumes a GUI and OpenGL viewers exist.

## Changes

1. **`main_window` null derefs** — `load_project_model_and_ui()` and its `set_path → project_name_changed` callback dereferenced `main_window` unconditionally (`notify`, `takeCentralWidget`, `setCentralWidget`, `setup_connections_with_project`, `on_project_name_changed`). Guard each; null-initialise the pointer.

2. **3D viewer crash** — a `Viewer3D` (OpenGL) was created per `GraphEditorWidget`, on viewport requests, and when restoring saved viewer state in `GraphNodeWidget::json_from`. Headless, it received paint events with no real window context and crashed in `qtr::RenderWidget::render_ui_render_3d()`. A new `AppContext::headless` runtime flag gates all three `Viewer3D` creation/restoration sites (`RenderWidget` is only ever created by `Viewer3D`; existing `get_viewer()` callers already null-guard).

3. **Snapshot framing / noise** — `run_snapshot_generation()` now hides the node-library pan (so the graph fills the 512×512 frame) and disables the WebEngine texture downloader, restoring all settings afterwards.

4. **Resilience** — one broken example (e.g. a stale port name in a shipped `.hsd`) threw an uncaught exception and aborted the whole batch. Each example's load+render is now wrapped in try/catch: log and skip, then continue.

GUI startup is unaffected (`headless` is false there, and `main_window` is always set by the time the GUI path runs).

## Test plan

- Built and ran `./bin/hesiod --snapshot` headless (XWayland): full run completes `Badlands` → `ZeroedEdges`, **54 `*_hsd_example.png` generated**, no segfault.
- Two shipped examples with a stale `texture in` port (`SnowMeltingMap.hsd`, `SnowSimulation.hsd`) are now logged and skipped instead of aborting the run (their port data is a separate fix).
- Normal GUI launch unaffected.

## Notes

- A separate follow-up will improve snapshot framing for very small (2-node) graphs (`zoom_to_content`/`fitInView` is viewport-size dependent and lives in GNodeGUI).