### PR TITLE
Add CLI project file argument, Open Recent menu, and startup viewport fit

### DIFF
--- a/Hesiod/app/main.cpp
+++ b/Hesiod/app/main.cpp
@@ -41,5 +41,5 @@ int main(int argc, char *argv[])
     return app.exec();
   }
 
-  return 0;
+  return app.get_exit_code();
 }

--- a/Hesiod/include/hesiod/app/app_settings.hpp
+++ b/Hesiod/include/hesiod/app/app_settings.hpp
@@ -72,6 +72,10 @@ struct AppSettings
     std::string ready_made_path = "data/bootstraps";
     bool        save_backup_file = true;
     std::string online_help_url = "https://hesioddoc.readthedocs.io/en/latest/";
+
+    // recently opened/saved project files, most recent first
+    std::vector<std::string> recent_files = {};
+    int                      max_recent_files = 10;
   } global;
 
   struct Interface

--- a/Hesiod/include/hesiod/app/hesiod_application.hpp
+++ b/Hesiod/include/hesiod/app/hesiod_application.hpp
@@ -5,6 +5,7 @@
 
 #include <QApplication>
 #include <QCoreApplication>
+#include <QMenu>
 #include <QProgressBar>
 #include <QStandardPaths>
 
@@ -38,6 +39,7 @@ public:
   ~HesiodApplication();
 
   bool is_headless() const;
+  int  get_exit_code() const;
   void load_project_model_and_ui(const std::string &fname = "", bool keep_name = true);
   void save_project_model_and_ui(const std::string &fname);
   void save_backup(const std::string &fname);
@@ -62,6 +64,7 @@ private slots:
   void on_online_help();
   void on_project_settings();
   void on_quit();
+  void on_open_recent(const std::string &fname);
   void on_save();
   void on_save_as();
   void on_save_copy();
@@ -72,7 +75,9 @@ private slots:
   void on_project_name_changed();
 
 private:
+  void add_recent_file(const std::string &fname);
   void cleanup();
+  void rebuild_recent_files_menu();
   void setup_menu_bar();
 
   // --- Members (respect order for deletion)
@@ -81,9 +86,12 @@ private:
   std::unique_ptr<ProjectUI> project_ui;            // because top-level UI
   AppSettingsWindow         *app_settings_window;   // owned by MainWindow
 
+  QMenu *recent_files_menu = nullptr; // owned by the menu bar
+
   BlenderStreamer blender_streamer;
 
   bool headless = false;
+  int  headless_exit_code = 0;
 };
 
 } // namespace hesiod

--- a/Hesiod/include/hesiod/cli/batch_mode.hpp
+++ b/Hesiod/include/hesiod/cli/batch_mode.hpp
@@ -24,7 +24,13 @@ static std::istream &operator>>(std::istream &is, glm::ivec2 &vec2)
 namespace hesiod::cli
 {
 
-int parse_args(args::ArgumentParser &parser, int argc, char *argv[]);
+// returns -1 to continue with the GUI (startup_file is filled if a project
+// file was requested on the command line), or a process exit code (>= 0) if
+// the invocation was fully handled here (batch modes, --help, parse errors)
+int parse_args(args::ArgumentParser &parser,
+               int                   argc,
+               char                 *argv[],
+               std::string          &startup_file);
 
 void run_batch_mode(const std::string &filename,
                     const glm::ivec2  &shape,

--- a/Hesiod/include/hesiod/gui/widgets/main_window.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/main_window.hpp
@@ -1,6 +1,7 @@
 /* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General Public
    License. The full license is in the file LICENSE, distributed with this software. */
 #pragma once
+#include <QCloseEvent>
 #include <QMainWindow>
 #include <QProgressBar>
 
@@ -19,6 +20,11 @@ public:
   void restore_geometry();
   void save_geometry() const;
   void setup_connections_with_project();
+
+protected:
+  // settings are otherwise only saved through File > Quit; make sure they also
+  // persist when the window is closed by the window manager
+  void closeEvent(QCloseEvent *event) override;
 
 private:
   void setup_progress_bar();

--- a/Hesiod/src/app/app_settings.cpp
+++ b/Hesiod/src/app/app_settings.cpp
@@ -121,6 +121,8 @@ void AppSettings::json_from(nlohmann::json const &json)
                 "global.default_startup_project_file",
                 global.default_startup_project_file);
   json_safe_get(json, "global.save_backup_file", global.save_backup_file);
+  json_safe_get(json, "global.recent_files", global.recent_files);
+  json_safe_get(json, "global.max_recent_files", global.max_recent_files);
 
   json_safe_get(json,
                 "interface.enable_data_preview_in_node_body",
@@ -236,6 +238,8 @@ nlohmann::json AppSettings::json_to() const
   json["global.icon_path"] = global.icon_path;
   json["global.default_startup_project_file"] = global.default_startup_project_file;
   json["global.save_backup_file"] = global.save_backup_file;
+  json["global.recent_files"] = global.recent_files;
+  json["global.max_recent_files"] = global.max_recent_files;
 
   json["interface.enable_data_preview_in_node_body"] =
       interface.enable_data_preview_in_node_body;

--- a/Hesiod/src/app/hesiod_application.cpp
+++ b/Hesiod/src/app/hesiod_application.cpp
@@ -1,6 +1,7 @@
 /* Copyright (c) 2025 Otto Link. Distributed under the terms of the GNU General
  * Public License. The full license is in the file LICENSE, distributed with
  * this software. */
+#include <algorithm>
 #include <format>
 #include <fstream>
 #include <iostream>
@@ -81,12 +82,14 @@ HesiodApplication::HesiodApplication(int &argc, char **argv) : QApplication(argc
   // --- Batch CLI mode if requested
 
   args::ArgumentParser parser("Hesiod.");
-  int                  ret = cli::parse_args(parser, argc, argv);
+  std::string          startup_file;
+  int                  ret = cli::parse_args(parser, argc, argv, startup_file);
 
   if (ret >= 0)
   {
     // stop here, skip the rest
     this->headless = true;
+    this->headless_exit_code = ret;
     return;
   }
 
@@ -109,8 +112,26 @@ HesiodApplication::HesiodApplication(int &argc, char **argv) : QApplication(argc
   splash->show_message("Loading project...");
 
   std::string fname = "";
+  bool        keep_name = false; // project name not kept (examples, default project)
 
-  if (this->context.app_settings.interface.enable_example_selector_at_startup)
+  if (!startup_file.empty())
+  {
+    if (fs::exists(startup_file))
+    {
+      fname = fs::absolute(fs::path(startup_file)).lexically_normal().string();
+      keep_name = true; // opened as a regular project, saving writes back to it
+    }
+    else
+    {
+      Logger::log()->warn("HesiodApplication::HesiodApplication: project file "
+                          "requested on the command line does not exist, falling back "
+                          "to normal startup: {}",
+                          startup_file);
+    }
+  }
+
+  if (fname.empty() &&
+      this->context.app_settings.interface.enable_example_selector_at_startup)
   {
     std::string path = this->context.app_settings.global.ready_made_path;
     auto       *ex_dialog = new ExampleSelectorDialog(QString::fromStdString(path));
@@ -120,8 +141,10 @@ HesiodApplication::HesiodApplication(int &argc, char **argv) : QApplication(argc
       fname = ex_dialog->selected_file().toStdString();
   }
 
-  bool keep_name = false; // project name not kept
   this->load_project_model_and_ui(fname, keep_name);
+
+  if (keep_name)
+    this->add_recent_file(fname);
 
   // others
   splash->show_message("Opening UI...");
@@ -135,6 +158,56 @@ HesiodApplication::HesiodApplication(int &argc, char **argv) : QApplication(argc
 }
 
 HesiodApplication::~HesiodApplication() = default;
+
+void HesiodApplication::rebuild_recent_files_menu()
+{
+  Logger::log()->trace("HesiodApplication::rebuild_recent_files_menu");
+
+  this->recent_files_menu->clear();
+
+  const std::vector<std::string> recent_files = this->context.app_settings.global
+                                                    .recent_files;
+
+  if (recent_files.empty())
+  {
+    QAction *empty_action = this->recent_files_menu->addAction("(no recent files)");
+    empty_action->setEnabled(false);
+    return;
+  }
+
+  for (const std::string &fname : recent_files)
+  {
+    QAction *action = this->recent_files_menu->addAction(QString::fromStdString(fname));
+    this->connect(action,
+                  &QAction::triggered,
+                  this,
+                  [this, fname]() { this->on_open_recent(fname); });
+  }
+
+  this->recent_files_menu->addSeparator();
+
+  QAction *clear_action = this->recent_files_menu->addAction("Clear Recent Files");
+  this->connect(clear_action,
+                &QAction::triggered,
+                this,
+                [this]() { this->context.app_settings.global.recent_files.clear(); });
+}
+
+void HesiodApplication::add_recent_file(const std::string &fname)
+{
+  Logger::log()->trace("HesiodApplication::add_recent_file: {}", fname);
+
+  auto &global = this->context.app_settings.global;
+
+  const std::string abs_path = fs::absolute(fs::path(fname)).lexically_normal().string();
+
+  auto &list = global.recent_files;
+  list.erase(std::remove(list.begin(), list.end(), abs_path), list.end());
+  list.insert(list.begin(), abs_path);
+
+  if (static_cast<int>(list.size()) > global.max_recent_files)
+    list.resize(std::max(global.max_recent_files, 0));
+}
 
 void HesiodApplication::cleanup()
 {
@@ -161,6 +234,8 @@ ProjectUI *HesiodApplication::get_project_ui_ref() { return this->project_ui.get
 QApplication &HesiodApplication::get_qapp() { return *static_cast<QApplication *>(this); }
 
 bool HesiodApplication::is_headless() const { return this->headless; }
+
+int HesiodApplication::get_exit_code() const { return this->headless_exit_code; }
 
 void HesiodApplication::load_project_model_and_ui(const std::string &fname,
                                                   bool               keep_name)
@@ -417,7 +492,31 @@ void HesiodApplication::on_load()
                                                     "Hesiod files (*.hsd)");
 
   if (!load_fname.isNull() && !load_fname.isEmpty())
+  {
     this->load_project_model_and_ui(load_fname.toStdString());
+    this->add_recent_file(load_fname.toStdString());
+  }
+}
+
+void HesiodApplication::on_open_recent(const std::string &fname)
+{
+  Logger::log()->trace("HesiodApplication::on_open_recent: {}", fname);
+
+  if (!fs::exists(fname))
+  {
+    QMessageBox::warning(
+        this->main_window,
+        "Open Recent",
+        QString("This file no longer exists and has been removed from the list:\n%1")
+            .arg(fname.c_str()));
+
+    auto &list = this->context.app_settings.global.recent_files;
+    list.erase(std::remove(list.begin(), list.end(), fname), list.end());
+    return;
+  }
+
+  this->load_project_model_and_ui(fname);
+  this->add_recent_file(fname);
 }
 
 void HesiodApplication::on_load_ready_made()
@@ -507,6 +606,7 @@ void HesiodApplication::on_save()
   {
     this->save_project_model_and_ui(path.string());
     this->context.project_model->set_path(path);
+    this->add_recent_file(path.string());
   }
 }
 
@@ -531,6 +631,7 @@ void HesiodApplication::on_save_as()
 
     this->save_project_model_and_ui(clean_path.string());
     this->context.project_model->set_path(clean_path.string());
+    this->add_recent_file(clean_path.string());
   }
 }
 
@@ -672,6 +773,8 @@ void HesiodApplication::setup_menu_bar()
   load_action->setShortcut(tr("Ctrl+O"));
   file_menu->addAction(load_action);
 
+  this->recent_files_menu = file_menu->addMenu("Open Recent");
+
   auto *rmade_action = new QAction("Open Ready-made Example", this);
   rmade_action->setIcon(HSD_ICON("landscape"));
   file_menu->addAction(rmade_action);
@@ -782,6 +885,10 @@ void HesiodApplication::setup_menu_bar()
 
   this->connect(new_action, &QAction::triggered, this, &HesiodApplication::on_new);
   this->connect(load_action, &QAction::triggered, this, &HesiodApplication::on_load);
+  this->connect(this->recent_files_menu,
+                &QMenu::aboutToShow,
+                this,
+                &HesiodApplication::rebuild_recent_files_menu);
   this->connect(rmade_action,
                 &QAction::triggered,
                 this,

--- a/Hesiod/src/app/hesiod_application.cpp
+++ b/Hesiod/src/app/hesiod_application.cpp
@@ -14,6 +14,7 @@
 #include <QMessageBox>
 #include <QProgressDialog>
 #include <QStatusBar>
+#include <QTimer>
 #include <QUrl>
 
 #include <omp.h>
@@ -1019,6 +1020,19 @@ void HesiodApplication::show()
 {
   Logger::log()->trace("HesiodApplication::show");
   this->main_window->show();
+
+  // the zoom-to-content deferred while deserializing the project fires before
+  // the main window is shown, so it fits against a not-yet-laid-out viewport
+  // and the graph can end up off-screen; refit once geometries are final
+  QTimer::singleShot(0,
+                     this,
+                     [this]()
+                     {
+                       if (this->project_ui &&
+                           this->project_ui->get_graph_tabs_widget_ref())
+                         this->project_ui->get_graph_tabs_widget_ref()
+                             ->zoom_to_content();
+                     });
 }
 
 void HesiodApplication::show_about()

--- a/Hesiod/src/cli/batch_mode.cpp
+++ b/Hesiod/src/cli/batch_mode.cpp
@@ -18,9 +18,22 @@
 namespace hesiod::cli
 {
 
-int parse_args(args::ArgumentParser &parser, int argc, char *argv[])
+int parse_args(args::ArgumentParser &parser,
+               int                   argc,
+               char                 *argv[],
+               std::string          &startup_file)
 {
   args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
+
+  args::ValueFlag<std::string> file_flag(parser,
+                                         "hsd file",
+                                         "Project file (.hsd) to open at startup",
+                                         {'f', "file"});
+
+  args::Positional<std::string> file_positional(
+      parser,
+      "file",
+      "Project file (.hsd) to open at startup");
 
   args::Group group(parser,
                     "This group is all exclusive:",
@@ -78,6 +91,21 @@ int parse_args(args::ArgumentParser &parser, int argc, char *argv[])
       run_node_inventory();
       return 0;
     }
+
+    if (file_flag && file_positional &&
+        args::get(file_flag) != args::get(file_positional))
+    {
+      std::cerr << "Error: conflicting project files requested: positional argument is "
+                << "'" << args::get(file_positional) << "' but -f/--file is "
+                << "'" << args::get(file_flag) << "'. "
+                << "Provide only one of them (or make them identical)." << std::endl;
+      return 1;
+    }
+
+    if (file_flag)
+      startup_file = args::get(file_flag);
+    else if (file_positional)
+      startup_file = args::get(file_positional);
   }
   catch (const args::Help &help)
   {

--- a/Hesiod/src/gui/widgets/main_window.cpp
+++ b/Hesiod/src/gui/widgets/main_window.cpp
@@ -19,6 +19,16 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
   this->setup_progress_bar();
 }
 
+void MainWindow::closeEvent(QCloseEvent *event)
+{
+  Logger::log()->trace("MainWindow::closeEvent");
+
+  this->save_geometry();
+  HSD_CTX.save_settings();
+
+  QMainWindow::closeEvent(event);
+}
+
 void MainWindow::notify(const std::string &msg, int timeout)
 {
   this->statusBar()->showMessage(msg.c_str(), timeout);

--- a/docs/guides/batch-headless.md
+++ b/docs/guides/batch-headless.md
@@ -14,6 +14,34 @@ into valid `.hsd` files and drives the binary programmatically.
 
 ---
 
+## Opening a project from the command line
+
+Independently of batch mode, the binary accepts a project file to open **in the GUI** —
+useful for shell aliases, file-manager associations, and scripted workflows that end with
+a visual check:
+
+```
+hesiod myproject.hsd
+hesiod -f myproject.hsd
+hesiod --file myproject.hsd
+```
+
+The three forms are equivalent; `-f`/`--file` is easier to keep unambiguous in scripts
+that pass several flags. The example-selector dialog is skipped and the file behaves as
+a regularly opened project (Ctrl+S saves back to it, and it is added to the
+**File → Open Recent** menu).
+
+- If the positional argument and `-f/--file` are both given **with different values**,
+  Hesiod prints an error explaining the conflict and exits with a non-zero status.
+- If the file does not exist, a warning is logged and startup continues as if no file
+  had been given.
+
+The **Open Recent** list is stored in the settings JSON (`~/.config/hesiod/hesiod.json`
+on Linux) under `global.recent_files`; its length is capped by `global.max_recent_files`
+(default 10).
+
+---
+
 ## Built-in batch mode
 
 The Hesiod binary accepts a `--batch` flag that loads a `.hsd` graph file and renders it


### PR DESCRIPTION
## What

- **Open a project from the command line**: `hesiod myproject.hsd`, or equivalently `hesiod -f myproject.hsd` / `hesiod --file myproject.hsd` (the flag form is friendlier for scripting). The example-selector dialog is skipped and Ctrl+S saves back to the opened file.
  - If the positional argument and `-f/--file` are both given with different values, Hesiod prints an explanatory error and exits with a non-zero status instead of silently picking one.
  - A nonexistent path logs a warning and falls back to the normal startup flow.
- **File > Open Recent submenu**: populated on open/save (deduped, most recent first, capped by the new `global.max_recent_files` setting, default 10), persisted in the settings JSON via the new `global.recent_files` key. Entries whose file has disappeared show a warning and are dropped from the list; a "Clear Recent Files" action empties it. Ready-made examples, "Save a copy" snapshots, and bake-temp files are deliberately not recorded.
- **Settings persistence on window close**: settings were only saved through File > Quit; closing the main window via the window manager skipped `save_settings` (and `save_geometry`). `MainWindow::closeEvent` now handles this, so recent files and window geometry persist on any exit path.
- **Startup viewport fit**: the zoom-to-content deferred by `GraphNodeWidget::json_from` fired before the main window was shown (flushed by the splash screen's event processing), so it fit against a not-yet-laid-out viewport and the graph could land off-screen until the user panned/zoomed. `HesiodApplication::show()` now refits once geometries are final.
- `main()` now propagates the headless exit code from `parse_args` (previously always 0, even on CLI parse errors).
- Documented the new CLI argument and settings keys in `docs/guides/batch-headless.md`.

## Testing

- `hesiod --help` shows the new positional and `-f/--file` options; existing `--batch` / `--snapshot` / `--inventory` modes unchanged
- `hesiod one.hsd -f two.hsd` errors out with the conflict message, exit code 1
- GUI-tested on Linux: opening a file from the CLI centers the graph in the viewport, recent files populate/dedupe/persist across restarts (both File > Quit and window close), missing recent entries are cleaned up with a warning dialog