### PR TITLE
Meta migration (phase 1): integrate otto-link/Meta, migrate first nodes, ui.data_provider + panel UX

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "external/QTextureDownloader"]
 	path = external/QTextureDownloader
 	url = git@github.com:otto-link/QTextureDownloader.git
+[submodule "external/Meta"]
+	path = external/Meta
+	url = git@github.com:otto-link/Meta.git

--- a/Hesiod/CMakeLists.txt
+++ b/Hesiod/CMakeLists.txt
@@ -80,6 +80,8 @@ target_link_libraries(
           gnode
           gnodegui
           attributes
+          meta
+          meta_qt
           Qt6::Core
           Qt6::OpenGL
           Qt6::Widgets

--- a/Hesiod/include/hesiod/gui/widgets/node_attributes_widget.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/node_attributes_widget.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "attributes/widgets/attributes_widget.hpp"
+#include "meta_qt/container_group_widget.hpp"
 
 #include "hesiod/gui/widgets/graph_node_widget.hpp"
 #include "hesiod/model/graph/graph_node.hpp"
@@ -30,6 +31,9 @@ public:
 
   attr::AttributesWidget *get_attributes_widget_ref();
 
+  void sync_from_model();
+  bool is_meta_backed() const;
+
 private:
   QWidget *create_toolbar();
   void     setup_connections();
@@ -40,7 +44,8 @@ private:
   QPointer<GraphNodeWidget> p_graph_node_widget;
   bool                      add_toolbar;
 
-  attr::AttributesWidget *attributes_widget;
+  attr::AttributesWidget            *attributes_widget;
+  meta::qt::ContainerGroupWidget    *meta_widget = nullptr;
 };
 
 } // namespace hesiod

--- a/Hesiod/include/hesiod/gui/widgets/node_settings_widget.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/node_settings_widget.hpp
@@ -5,6 +5,7 @@
 #include <QVBoxLayout>
 
 #include "hesiod/gui/widgets/graph_node_widget.hpp"
+#include "hesiod/gui/widgets/node_attributes_widget.hpp"
 
 namespace hesiod
 {
@@ -24,6 +25,7 @@ private:
   void setup_connections();
   void setup_layout();
   void update_content();
+  void sync_content();
 
   // --- Members ---
   QPointer<GraphNodeWidget> p_graph_node_widget; // own by GraphManagerWidget
@@ -31,6 +33,7 @@ private:
   std::vector<std::string>  pinned_node_ids;
   std::vector<std::string>  last_selected_ids; // kept so the pane does not blank
                                                // out when nodes are deselected
+  std::vector<QPointer<NodeAttributesWidget>> attr_widgets;
 };
 
 } // namespace hesiod

--- a/Hesiod/include/hesiod/model/nodes/base_node.hpp
+++ b/Hesiod/include/hesiod/model/nodes/base_node.hpp
@@ -12,6 +12,7 @@
 #include "gnodegui/node_proxy.hpp"
 
 #include "attributes/abstract_attribute.hpp"
+#include "meta/core/container_group.hpp"
 
 #include "hesiod/model/graph/graph_config.hpp"
 #include "hesiod/model/nodes/node_runtime_info.hpp"
@@ -107,6 +108,10 @@ public:
   std::map<std::string, std::unique_ptr<attr::AbstractAttribute>> *get_attributes_ref();
   void set_attr_ordered_key(const std::vector<std::string> &new_attr_ordered_key);
 
+  bool                        uses_meta() const;
+  meta::ContainerGroup       &meta_group();       // lazily creates group + "main" container
+  const meta::ContainerGroup &meta_group() const;
+
   void reseed(bool backward);
 
   // --- Callbacks - "signals" equivalent
@@ -116,6 +121,7 @@ public:
 private:
   // --- Members ---
   std::map<std::string, std::unique_ptr<attr::AbstractAttribute>> attr = {};
+  std::unique_ptr<meta::ContainerGroup> meta_group_; // opt-in Meta storage (nullptr = legacy attr map)
 
   std::vector<std::string>            attr_ordered_key = {};
   std::string                         category;

--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -137,16 +137,20 @@ void GraphEditorWidget::setup_layout()
     row_offset++;
   }
 
-  // left pan with splitter
+  // graph area: viewer/graph vertical splitter + toolbar, wrapped so it can be
+  // one pane of the horizontal splitter below.
+  QWidget     *graph_container = new QWidget();
+  QVBoxLayout *graph_layout = new QVBoxLayout(graph_container);
+  graph_layout->setContentsMargins(0, 0, 0, 0);
+  graph_layout->setSpacing(0);
+
   {
     QSplitter *splitter = new QSplitter(Qt::Vertical);
     splitter->setChildrenCollapsible(false);
 
     this->graph_node_widget = new GraphNodeWidget(gno->get_shared());
 
-    // skip the 3D viewer (OpenGL) in headless CLI modes (e.g. --snapshot): it
-    // would receive paint events and crash without a real GUI window context.
-    // get_viewer() stays null and every caller already null-guards it.
+    // skip the 3D viewer (OpenGL) in headless CLI modes (e.g. --snapshot).
     if (!HSD_CTX.headless)
     {
       this->viewer = new Viewer3D(this->graph_node_widget);
@@ -155,29 +159,34 @@ void GraphEditorWidget::setup_layout()
     }
 
     splitter->addWidget(this->graph_node_widget);
-
-    layout->addWidget(splitter, 0, row_offset);
+    graph_layout->addWidget(splitter);
   }
 
-  // right pan
   {
-    this->node_settings_widget = new NodeSettingsWidget(this->graph_node_widget);
+    auto *graph_toolbar = new GraphToolbar(this->graph_node_widget);
+    graph_layout->addWidget(graph_toolbar);
+  }
 
+  // settings panel (created after graph_node_widget, which it takes).
+  this->node_settings_widget = new NodeSettingsWidget(this->graph_node_widget);
+  {
     std::string color = HSD_CTX.app_settings.colors.border.name().toStdString();
     set_style(this->node_settings_widget,
               std::format("border-left: 1px solid {};", color));
-
-    layout->addWidget(this->node_settings_widget, 0, row_offset + 1, 2, 1);
-
     this->node_settings_widget->setVisible(
         HSD_CTX.app_settings.node_editor.show_node_settings_pan);
   }
 
-  // bottom toolbar
-  {
-    auto *graph_toolbar = new GraphToolbar(this->graph_node_widget);
-    layout->addWidget(graph_toolbar, 1, row_offset);
-  }
+  // horizontal splitter: [ graph area | settings ] — user-resizable.
+  QSplitter *h_splitter = new QSplitter(Qt::Horizontal);
+  h_splitter->setChildrenCollapsible(false);
+  h_splitter->addWidget(graph_container);
+  h_splitter->addWidget(this->node_settings_widget);
+  h_splitter->setStretchFactor(0, 1); // graph area absorbs window resizing
+  h_splitter->setStretchFactor(1, 0); // settings keeps its width
+  h_splitter->setSizes({900, 400});   // default: graph large, settings ~400px
+
+  layout->addWidget(h_splitter, 0, row_offset, 2, 1);
 
   // --- Connection(s)
 

--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -184,9 +184,13 @@ void GraphEditorWidget::setup_layout()
   h_splitter->addWidget(this->node_settings_widget);
   h_splitter->setStretchFactor(0, 1); // graph area absorbs window resizing
   h_splitter->setStretchFactor(1, 0); // settings keeps its width
-  h_splitter->setSizes({900, 400});   // default: graph large, settings ~400px
+  h_splitter->setSizes({650, 500});   // default: settings opens wide enough for paired sliders
 
   layout->addWidget(h_splitter, 0, row_offset, 2, 1);
+
+  // Give the graph/settings splitter column the window's spare width so it always
+  // has room to drag (otherwise the split only widens when the whole window grows).
+  layout->setColumnStretch(row_offset, 1);
 
   // --- Connection(s)
 

--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -149,6 +149,8 @@ void GraphEditorWidget::setup_layout()
     splitter->setChildrenCollapsible(false);
 
     this->graph_node_widget = new GraphNodeWidget(gno->get_shared());
+    this->graph_node_widget->setMinimumWidth(50); // let the graph pane shrink so the
+                                                  // settings pane can be dragged wider
 
     // skip the 3D viewer (OpenGL) in headless CLI modes (e.g. --snapshot).
     if (!HSD_CTX.headless)

--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -6,6 +6,8 @@
 #include <QStyle>
 #include <QToolButton>
 
+#include "meta_qt/container_group_widget.hpp"
+
 #include "hesiod/app/hesiod_application.hpp"
 #include "hesiod/gui/widgets/documentation_popup.hpp"
 #include "hesiod/gui/widgets/node_attributes_widget.hpp"
@@ -199,6 +201,35 @@ void NodeAttributesWidget::setup_layout()
   BaseNode *p_node = gno->get_node_ref_by_id<BaseNode>(this->node_id);
   if (!p_node)
     return;
+
+  if (p_node->uses_meta())
+  {
+    // Meta-backed node: render with meta_qt, skip the legacy AttributesWidget path.
+    this->attributes_widget = nullptr; // so setup_connections() skips the legacy wiring
+
+    auto *meta_widget = new meta::qt::ContainerGroupWidget(p_node->meta_group(),
+                                                           meta::qt::ContainerRenderOptions{},
+                                                           this);
+
+    this->connect(meta_widget,
+                  &meta::qt::MetaWidget::value_changed,
+                  this,
+                  [this]()
+                  {
+                    auto gno = this->p_graph_node.lock();
+                    if (!gno)
+                      return;
+                    gno->update(this->node_id);
+                  });
+
+    QVBoxLayout *main_layout = new QVBoxLayout(this);
+    main_layout->setSpacing(4);
+    main_layout->setContentsMargins(0, 0, 0, 0);
+    if (this->add_toolbar)
+      main_layout->addWidget(this->create_toolbar());
+    main_layout->addWidget(meta_widget);
+    return;
+  }
 
   // generate a fresh widget
   bool        add_save_reset_state_buttons = false;

--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -214,8 +214,13 @@ void NodeAttributesWidget::setup_layout()
                                                            meta::qt::ContainerRenderOptions{},
                                                            this);
 
+    // Recompute on edit_ended (commit/drag-release), NOT the continuous
+    // value_changed: the panel is rebuilt on update_finished, so recomputing on
+    // every value_changed would destroy a live-dragged widget mid-drag. All
+    // widget types emit edit_ended (discrete edits emit it alongside
+    // value_changed; drags emit it on release), so no edit is missed.
     this->connect(meta_widget,
-                  &meta::qt::MetaWidget::value_changed,
+                  &meta::qt::MetaWidget::edit_ended,
                   this,
                   [this]()
                   {

--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -100,21 +100,24 @@ QWidget *NodeAttributesWidget::create_toolbar()
                     this->p_graph_node_widget->on_node_info(this->node_id);
                 });
 
+  // These state/preset buttons operate on the legacy AttributesWidget, which is
+  // null for meta-backed nodes; guard against a null deref (meta nodes use Meta's
+  // own snapshot/preset system, wired separately later).
   this->connect(bckp_btn,
                 &QToolButton::pressed,
-                [this]() { this->attributes_widget->on_save_state(); });
+                [this]() { if (this->attributes_widget) this->attributes_widget->on_save_state(); });
   this->connect(revert_btn,
                 &QToolButton::pressed,
-                [this]() { this->attributes_widget->on_restore_save_state(); });
+                [this]() { if (this->attributes_widget) this->attributes_widget->on_restore_save_state(); });
   this->connect(load_btn,
                 &QToolButton::pressed,
-                [this]() { this->attributes_widget->on_load_preset(); });
+                [this]() { if (this->attributes_widget) this->attributes_widget->on_load_preset(); });
   this->connect(save_btn,
                 &QToolButton::pressed,
-                [this]() { this->attributes_widget->on_save_preset(); });
+                [this]() { if (this->attributes_widget) this->attributes_widget->on_save_preset(); });
   this->connect(reset_btn,
                 &QToolButton::pressed,
-                [this]() { this->attributes_widget->on_restore_initial_state(); });
+                [this]() { if (this->attributes_widget) this->attributes_widget->on_restore_initial_state(); });
 
   this->connect(help_btn,
                 &QToolButton::pressed,

--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -163,6 +163,15 @@ attr::AttributesWidget *NodeAttributesWidget::get_attributes_widget_ref()
   return this->attributes_widget;
 }
 
+void NodeAttributesWidget::sync_from_model()
+{
+  if (this->meta_widget)
+    this->meta_widget->on_sync_meta_widgets_from_model();
+  // legacy attr::AttributesWidget: values are the source of truth, no model sync needed.
+}
+
+bool NodeAttributesWidget::is_meta_backed() const { return this->meta_widget != nullptr; }
+
 void NodeAttributesWidget::setup_connections()
 {
   Logger::log()->trace("NodeAttributesWidget::setup_connections");
@@ -210,17 +219,16 @@ void NodeAttributesWidget::setup_layout()
     // Meta-backed node: render with meta_qt, skip the legacy AttributesWidget path.
     this->attributes_widget = nullptr; // so setup_connections() skips the legacy wiring
 
-    auto *meta_widget = new meta::qt::ContainerGroupWidget(p_node->meta_group(),
+    this->meta_widget = new meta::qt::ContainerGroupWidget(p_node->meta_group(),
                                                            meta::qt::ContainerRenderOptions{},
                                                            this);
 
-    // Recompute on edit_ended (commit/drag-release), NOT the continuous
-    // value_changed: the panel is rebuilt on update_finished, so recomputing on
-    // every value_changed would destroy a live-dragged widget mid-drag. All
-    // widget types emit edit_ended (discrete edits emit it alongside
-    // value_changed; drags emit it on release), so no edit is missed.
-    this->connect(meta_widget,
-                  &meta::qt::MetaWidget::edit_ended,
+    // Recompute continuously on value_changed: the panel now syncs from the
+    // model (sync_from_model()) instead of being rebuilt on update_finished, so
+    // recomputing on every value_changed no longer destroys a live-dragged
+    // widget mid-drag.
+    this->connect(this->meta_widget,
+                  &meta::qt::MetaWidget::value_changed,
                   this,
                   [this]()
                   {
@@ -235,7 +243,7 @@ void NodeAttributesWidget::setup_layout()
     main_layout->setContentsMargins(0, 0, 0, 0);
     if (this->add_toolbar)
       main_layout->addWidget(this->create_toolbar());
-    main_layout->addWidget(meta_widget);
+    main_layout->addWidget(this->meta_widget);
     return;
   }
 

--- a/Hesiod/src/gui/widgets/node_settings_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_settings_widget.cpp
@@ -49,7 +49,7 @@ void NodeSettingsWidget::setup_connections()
   this->connect(this->p_graph_node_widget,
                 &GraphNodeWidget::update_finished,
                 this,
-                &NodeSettingsWidget::update_content);
+                &NodeSettingsWidget::sync_content);
 }
 
 void NodeSettingsWidget::setup_layout()
@@ -90,6 +90,7 @@ void NodeSettingsWidget::update_content()
     return;
 
   clear_layout(this->attr_layout);
+  this->attr_widgets.clear();
 
   // lifetime safe getter
   GraphNode *p_gno = this->p_graph_node_widget->get_p_graph_node();
@@ -163,9 +164,34 @@ void NodeSettingsWidget::update_content()
 
     this->attr_layout->addWidget(attr_widget);
     this->attr_layout->addWidget(new QLabel()); // space
+
+    this->attr_widgets.push_back(attr_widget);
   }
 
   this->attr_layout->addStretch();
+}
+
+void NodeSettingsWidget::sync_content()
+{
+  Logger::log()->trace("NodeSettingsWidget::sync_content");
+
+  // Rebuild if the panel is empty or contains any legacy (non-meta) widget.
+  if (this->attr_widgets.empty())
+  {
+    this->update_content();
+    return;
+  }
+  for (const auto &w : this->attr_widgets)
+    if (!w || !w->is_meta_backed())
+    {
+      this->update_content();
+      return;
+    }
+
+  // Pure-meta panel: sync in place, no teardown.
+  for (const auto &w : this->attr_widgets)
+    if (w)
+      w->sync_from_model();
 }
 
 } // namespace hesiod

--- a/Hesiod/src/gui/widgets/node_settings_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_settings_widget.cpp
@@ -25,8 +25,7 @@ NodeSettingsWidget::NodeSettingsWidget(QPointer<GraphNodeWidget> p_graph_node_wi
   if (!this->p_graph_node_widget)
     return;
 
-  this->setMinimumWidth(360); // TODO fix this
-  this->setMaximumWidth(360);
+  this->setMinimumWidth(320); // splitter governs the actual width; never collapses below this
 
   this->setup_layout();
   this->setup_connections();
@@ -72,7 +71,7 @@ void NodeSettingsWidget::setup_layout()
     this->attr_layout->setSpacing(2);
 
     auto *scroll = new QScrollArea();
-    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     scroll->setWidget(container);
     scroll->setWidgetResizable(true);
     scroll->setFrameShape(QFrame::NoFrame);

--- a/Hesiod/src/gui/widgets/node_settings_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_settings_widget.cpp
@@ -175,20 +175,17 @@ void NodeSettingsWidget::sync_content()
 {
   Logger::log()->trace("NodeSettingsWidget::sync_content");
 
-  // Rebuild if the panel is empty or contains any legacy (non-meta) widget.
+  // Nothing built yet (e.g. no selection): do the initial build.
   if (this->attr_widgets.empty())
   {
     this->update_content();
     return;
   }
-  for (const auto &w : this->attr_widgets)
-    if (!w || !w->is_meta_backed())
-    {
-      this->update_content();
-      return;
-    }
 
-  // Pure-meta panel: sync in place, no teardown.
+  // Sync every widget in place, never tearing the panel down on recompute:
+  // meta widgets refresh from the model; legacy widgets no-op (their values are
+  // the source of truth). Because there is no teardown, a live-dragged widget is
+  // never destroyed mid-drag, even in a mixed meta+legacy panel.
   for (const auto &w : this->attr_widgets)
     if (w)
       w->sync_from_model();

--- a/Hesiod/src/gui/widgets/node_settings_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_settings_widget.cpp
@@ -25,7 +25,7 @@ NodeSettingsWidget::NodeSettingsWidget(QPointer<GraphNodeWidget> p_graph_node_wi
   if (!this->p_graph_node_widget)
     return;
 
-  this->setMinimumWidth(320); // splitter governs the actual width; never collapses below this
+  this->setMinimumWidth(360); // floor so single-value widgets fit; splitter governs actual width
 
   this->setup_layout();
   this->setup_connections();

--- a/Hesiod/src/gui/widgets/node_settings_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_settings_widget.cpp
@@ -25,7 +25,7 @@ NodeSettingsWidget::NodeSettingsWidget(QPointer<GraphNodeWidget> p_graph_node_wi
   if (!this->p_graph_node_widget)
     return;
 
-  this->setMinimumWidth(360); // floor so single-value widgets fit; splitter governs actual width
+  this->setMinimumWidth(240); // low floor so the pane is freely narrowable; wide content scrolls
 
   this->setup_layout();
   this->setup_connections();

--- a/Hesiod/src/model/nodes/base_node.cpp
+++ b/Hesiod/src/model/nodes/base_node.cpp
@@ -412,6 +412,22 @@ void BaseNode::json_from(nlohmann::json const &json)
       else
         Logger::log()->warn("Missing JSON key for attribute: {}, using default", key);
     }
+
+    if (this->uses_meta())
+    {
+      if (json.contains("_meta"))
+      {
+        this->meta_group().current().json_from(json["_meta"]);
+      }
+      else
+      {
+        Logger::log()->error(
+            "BaseNode::json_from: node '{}' uses Meta storage but the '_meta' key "
+            "is absent from the JSON — Meta parameters were NOT restored (refusing "
+            "to silently load defaults)",
+            this->get_id());
+      }
+    }
   }
   catch (const nlohmann::json::exception &e)
   {
@@ -433,6 +449,9 @@ nlohmann::json BaseNode::json_to() const
     json["label"] = this->get_label();
     json["comment"] = this->get_comment();
     json["runtime_info"] = this->runtime_info.json_to();
+
+    if (this->uses_meta())
+      json["_meta"] = this->meta_group().current().json_to();
   }
   catch (const std::exception &e)
   {

--- a/Hesiod/src/model/nodes/base_node.cpp
+++ b/Hesiod/src/model/nodes/base_node.cpp
@@ -104,6 +104,21 @@ std::vector<std::string> *BaseNode::get_attr_ordered_key_ref()
   return &this->attr_ordered_key;
 };
 
+bool BaseNode::uses_meta() const { return this->meta_group_ != nullptr; }
+
+meta::ContainerGroup &BaseNode::meta_group()
+{
+  if (!this->meta_group_)
+  {
+    this->meta_group_ = std::make_unique<meta::ContainerGroup>();
+    this->meta_group_->add("main");
+    this->meta_group_->set_current("main");
+  }
+  return *this->meta_group_;
+}
+
+const meta::ContainerGroup &BaseNode::meta_group() const { return *this->meta_group_; }
+
 std::string BaseNode::get_category() const { return this->category; }
 
 std::shared_ptr<const GraphConfig> BaseNode::get_config_ref() const

--- a/Hesiod/src/model/nodes/nodes_function/cloud.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/cloud.cpp
@@ -1,14 +1,18 @@
 /* Copyright (c) 2023 Otto Link. Distributed under the terms of the GNU General
  * Public License. The full license is in the file LICENSE, distributed with
  * this software. */
-#include "highmap/geometry/cloud.hpp"
+#include <algorithm>
 
-#include "attributes.hpp"
+#include "highmap/colorize.hpp"
+#include "highmap/geometry/cloud.hpp"
+#include "highmap/operator.hpp"
+#include "highmap/virtual_array/virtual_array.hpp"
+
+#include "meta/core/data_provider.hpp"
+#include "meta/metadata/keys.hpp"
 
 #include "hesiod/logger.hpp"
 #include "hesiod/model/nodes/base_node.hpp"
-
-using namespace attr;
 
 namespace hesiod
 {
@@ -36,14 +40,39 @@ void setup_cloud_node(BaseNode &node)
   node.add_port<hmap::Cloud>(gnode::PortType::OUT, P_OUT);
 
   // --- Attributes
-  node.add_attr<CloudAttribute>(A_CLOUD, "Cloud");
 
-  // --- Attribute(s) order
+  auto &c = node.meta_group().current();
 
-  node.set_attr_ordered_key(
-      {"_GROUPBOX_BEGIN_Main Parameters", A_CLOUD, "_GROUPBOX_END_"});
-
-  setup_background_image_for_cloud_attribute(node, A_CLOUD, P_BACKGROUND);
+  auto *a = c.add<std::vector<glm::vec3>>(A_CLOUD, {});
+  a->metadata().try_add(meta::keys::ui::label, std::string("Cloud"));
+  a->metadata().try_add(meta::keys::ui::widget_type, std::string("PointsEditor"));
+  a->metadata().try_add(meta::keys::ui::category, std::string("Main"));
+  a->metadata().try_add(
+      meta::keys::ui::data_provider,
+      meta::DataProvider{
+          [&node, port_id = std::string(P_BACKGROUND)]() -> meta::ProviderData
+          {
+            meta::ProviderData d;
+            hmap::VirtualArray *p_in = node.get_value_ref<hmap::VirtualArray>(port_id);
+            if (!p_in)
+              return d;
+            const glm::ivec2 shape(256, 256);
+            hmap::Array array = p_in->to_array(shape, node.cfg().cm_cpu);
+            std::vector<uint8_t> img =
+                hmap::colorize(array, array.min(), array.max(), hmap::Cmap::MAGMA, false)
+                    .to_img_8bit();
+            d.image_width = shape.x;
+            d.image_height = shape.y;
+            d.image_channels = 3; // to_img_8bit() -> RGB
+            // vertical flip so the thumbnail origin matches the canvas (legacy mirrored(false,true))
+            const int stride = shape.x * 3;
+            d.image_pixels.resize(img.size());
+            for (int y = 0; y < shape.y; ++y)
+              std::copy_n(img.data() + (shape.y - 1 - y) * stride,
+                          stride,
+                          d.image_pixels.data() + y * stride);
+            return d;
+          }});
 }
 
 // -----------------------------------------------------------------------------
@@ -60,7 +89,8 @@ void compute_cloud_node(BaseNode &node)
 
   // --- Params
 
-  const auto cloud_attr = node.get_attr<CloudAttribute>(A_CLOUD);
+  const auto cloud_attr =
+      node.meta_group().current().value<std::vector<glm::vec3>>(A_CLOUD);
 
   // --- Compute
 

--- a/Hesiod/src/model/nodes/nodes_function/noise.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/noise.cpp
@@ -7,6 +7,8 @@
 
 #include "attributes.hpp"
 
+#include "meta/metadata/keys.hpp"
+
 #include "hesiod/app/enum_mappings.hpp"
 #include "hesiod/logger.hpp"
 #include "hesiod/model/nodes/base_node.hpp"
@@ -48,26 +50,46 @@ void setup_noise_node(BaseNode &node)
 
   // --- Attributes
 
-  // clang-format off
-  node.add_attr<EnumAttribute>(A_NOISE_TYPE, "Type", enum_mappings.noise_type_map);
-  node.add_attr<WaveNbAttribute>(A_KW, "Spatial Frequency");
-  node.add_attr<SeedAttribute>(A_SEED, "Seed");
-  node.add_attr<BoolAttribute>(A_PERIODIC, "Periodic (tileable)", false);
-  // clang-format on
+  auto &c = node.meta_group().current();
 
-  // --- Attribute(s) order
+  // noise_type: int-backed enum dropdown
+  {
+    auto *a = c.add<int>(A_NOISE_TYPE, 0);
+    a->metadata().try_add(meta::keys::ui::label, std::string("Type"));
+    a->metadata().try_add(meta::keys::ui::widget_type, std::string("EnumComboBox"));
+    a->metadata().try_add(meta::keys::ui::category, std::string("Main Parameters"));
+    std::vector<std::pair<int, std::string>> items;
+    for (const auto &[name, val] : enum_mappings.noise_type_map)
+      items.emplace_back(val, name);
+    a->metadata().try_add(meta::keys::constraints::enum_items, items);
+  }
 
-  node.set_attr_ordered_key({
-      "_GROUPBOX_BEGIN_Main Parameters",
-      A_NOISE_TYPE,
-      A_KW,
-      A_SEED,
-      "_GROUPBOX_END_",
-      //
-      "_GROUPBOX_BEGIN_Tiling",
-      A_PERIODIC,
-      "_GROUPBOX_END_",
-  });
+  // kw: 2D wavenumber with X/Y lock
+  {
+    auto *a = c.add<glm::vec2>(A_KW, glm::vec2(2.f, 2.f));
+    a->metadata().try_add(meta::keys::ui::label, std::string("Spatial Frequency"));
+    a->metadata().try_add(meta::keys::ui::widget_type, std::string("LinkedSliders"));
+    a->metadata().try_add(std::string("ui.locked_xy"), true);
+    a->metadata().try_add(meta::keys::constraints::min, 0.f);
+    a->metadata().try_add(meta::keys::constraints::max, 64.f);
+    a->metadata().try_add(meta::keys::ui::category, std::string("Main Parameters"));
+  }
+
+  // seed
+  {
+    auto *a = c.add<int>(A_SEED, 1);
+    a->metadata().try_add(meta::keys::ui::label, std::string("Seed"));
+    a->metadata().try_add(meta::keys::constraints::min, 0);
+    a->metadata().try_add(meta::keys::ui::category, std::string("Main Parameters"));
+  }
+
+  // periodic
+  {
+    auto *a = c.add<bool>(A_PERIODIC, false);
+    a->metadata().try_add(meta::keys::ui::label, std::string("Periodic (tileable)"));
+    a->metadata().try_add(meta::keys::ui::widget_type, std::string("Checkbox"));
+    a->metadata().try_add(meta::keys::ui::category, std::string("Tiling"));
+  }
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = false, .remap_active_state = true});
@@ -93,11 +115,13 @@ void compute_noise_node(BaseNode &node)
 
   // --- Params
 
+  auto &c = node.meta_group().current();
+
   // clang-format off
-  const auto noise_type = hmap::NoiseType(node.get_attr<EnumAttribute>(A_NOISE_TYPE));
-  const auto kw         = node.get_attr<WaveNbAttribute>(A_KW);
-  const auto seed       = node.get_attr<SeedAttribute>(A_SEED);
-  const auto periodic   = node.get_attr<BoolAttribute>(A_PERIODIC);
+  const auto      noise_type = hmap::NoiseType(c.value<int>(A_NOISE_TYPE));
+  const glm::vec2 kw         = c.value<glm::vec2>(A_KW);
+  const auto      seed       = static_cast<uint>(c.value<int>(A_SEED));
+  const auto      periodic   = c.value<bool>(A_PERIODIC);
   // clang-format on
 
   // --- Compute

--- a/Hesiod/src/model/nodes/nodes_function/noise.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/noise.cpp
@@ -54,7 +54,7 @@ void setup_noise_node(BaseNode &node)
 
   // noise_type: int-backed enum dropdown
   {
-    auto *a = c.add<int>(A_NOISE_TYPE, 0);
+    auto *a = c.add<int>(A_NOISE_TYPE, static_cast<int>(hmap::NoiseType::SIMPLEX2));
     a->metadata().try_add(meta::keys::ui::label, std::string("Type"));
     a->metadata().try_add(meta::keys::ui::widget_type, std::string("EnumComboBox"));
     a->metadata().try_add(meta::keys::ui::category, std::string("Main Parameters"));

--- a/Hesiod/src/model/nodes/nodes_function/saturate.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/saturate.cpp
@@ -48,8 +48,8 @@ void setup_saturate_node(BaseNode &node)
   {
     auto *a = c.add<glm::vec2>(A_RANGE, glm::vec2(0.f, 1.f));
     a->metadata().try_add(meta::keys::ui::widget_type, std::string("RangeBar"));
-    a->metadata().try_add(meta::keys::constraints::min, 0.f);
-    a->metadata().try_add(meta::keys::constraints::max, 1.f);
+    a->metadata().try_add(meta::keys::constraints::min, -1.f); // legacy RangeAttribute domain
+    a->metadata().try_add(meta::keys::constraints::max, 2.f);
     a->metadata().try_add(meta::keys::ui::category, std::string("Main"));
     a->metadata().try_add(meta::keys::ui::tooltip, std::string("<b>Saturation range</b>"));
     a->metadata().try_add(
@@ -73,7 +73,11 @@ void setup_saturate_node(BaseNode &node)
               const float sb = -vmin / (vmax - vmin) * (nbins - 1);
               for (int j = 0; j < arr.shape.y; ++j)
                 for (int i = 0; i < arr.shape.x; ++i)
-                  d.series_y[static_cast<int>(sa * arr(i, j) + sb)] += 1.f;
+                {
+                  int bin = static_cast<int>(sa * arr(i, j) + sb);
+                  bin = bin < 0 ? 0 : (bin >= nbins ? nbins - 1 : bin);
+                  d.series_y[bin] += 1.f;
+                }
               return d;
             }});
   }

--- a/Hesiod/src/model/nodes/nodes_function/saturate.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/saturate.cpp
@@ -6,6 +6,9 @@
 
 #include "attributes.hpp"
 
+#include "meta/core/data_provider.hpp"
+#include "meta/metadata/keys.hpp"
+
 #include "hesiod/logger.hpp"
 #include "hesiod/model/nodes/base_node.hpp"
 #include "hesiod/model/nodes/post_process.hpp"
@@ -15,23 +18,65 @@ using namespace attr;
 namespace hesiod
 {
 
+constexpr const char *P_IN = "input";
+constexpr const char *P_OUT = "output";
+
+constexpr const char *A_K_SMOOTHING = "k_smoothing";
+constexpr const char *A_RANGE = "range";
+
 void setup_saturate_node(BaseNode &node)
 {
   Logger::log()->trace("setup node {}", node.get_label());
 
   // port(s)
-  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, "input");
-  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, "output", CONFIG(node));
+  node.add_port<hmap::VirtualArray>(gnode::PortType::IN, P_IN);
+  node.add_port<hmap::VirtualArray>(gnode::PortType::OUT, P_OUT, CONFIG(node));
 
   // attribute(s)
-  node.add_attr<FloatAttribute>("k_smoothing", "k_smoothing", 0.1f, 0.01, 1.f);
-  node.add_attr<RangeAttribute>("range", "range");
+  auto &c = node.meta_group().current();
 
-  // link histogram for RangeAttribute
-  setup_histogram_for_range_attribute(node, "range", "input");
+  // k_smoothing
+  {
+    auto *a = c.add<float>(A_K_SMOOTHING, 0.1f);
+    a->metadata().try_add(meta::keys::ui::label, std::string("k_smoothing"));
+    a->metadata().try_add(meta::keys::constraints::min, 0.01f);
+    a->metadata().try_add(meta::keys::constraints::max, 1.f);
+    a->metadata().try_add(meta::keys::ui::category, std::string("Main"));
+  }
 
-  // attribute(s) order
-  node.set_attr_ordered_key({"k_smoothing", "range"});
+  // range
+  {
+    auto *a = c.add<glm::vec2>(A_RANGE, glm::vec2(0.f, 1.f));
+    a->metadata().try_add(meta::keys::ui::widget_type, std::string("RangeBar"));
+    a->metadata().try_add(meta::keys::constraints::min, 0.f);
+    a->metadata().try_add(meta::keys::constraints::max, 1.f);
+    a->metadata().try_add(meta::keys::ui::category, std::string("Main"));
+    a->metadata().try_add(meta::keys::ui::tooltip, std::string("<b>Saturation range</b>"));
+    a->metadata().try_add(
+        meta::keys::ui::data_provider,
+        meta::DataProvider{
+            [&node, port_id = std::string(P_IN)]() -> meta::ProviderData
+            {
+              meta::ProviderData d;
+              hmap::VirtualArray *p_in = node.get_value_ref<hmap::VirtualArray>(port_id);
+              if (!p_in)
+                return d;
+              float vmin = p_in->min(node.cfg().cm_cpu);
+              float vmax = p_in->max(node.cfg().cm_cpu);
+              if (vmin == vmax)
+                return d;
+              const int   nbins = 256;
+              hmap::Array arr = p_in->to_array({256, 256}, node.cfg().cm_cpu);
+              d.series_x = hmap::linspace(vmin, vmax, nbins, false);
+              d.series_y.assign(nbins, 0.f);
+              const float sa = 1.f / (vmax - vmin) * (nbins - 1);
+              const float sb = -vmin / (vmax - vmin) * (nbins - 1);
+              for (int j = 0; j < arr.shape.y; ++j)
+                for (int i = 0; i < arr.shape.x; ++i)
+                  d.series_y[static_cast<int>(sa * arr(i, j) + sb)] += 1.f;
+              return d;
+            }});
+  }
 
   setup_post_process_heightmap_attributes(node,
                                           {.add_mix = true, .remap_active_state = false});
@@ -41,29 +86,34 @@ void compute_saturate_node(BaseNode &node)
 {
   Logger::log()->trace("computing node [{}]/[{}]", node.get_label(), node.get_id());
 
-  hmap::VirtualArray *p_in = node.get_value_ref<hmap::VirtualArray>("input");
+  hmap::VirtualArray *p_in = node.get_value_ref<hmap::VirtualArray>(P_IN);
 
   if (p_in)
   {
-    hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>("output");
+    hmap::VirtualArray *p_out = node.get_value_ref<hmap::VirtualArray>(P_OUT);
 
     float hmin = p_in->min(node.cfg().cm_cpu);
     float hmax = p_in->max(node.cfg().cm_cpu);
 
+    auto &c = node.meta_group().current();
+
+    const glm::vec2 range = c.value<glm::vec2>(A_RANGE);
+    const float      k     = c.value<float>(A_K_SMOOTHING);
+
     hmap::for_each_tile(
         {p_out, p_in},
-        [&node, &hmin, &hmax](std::vector<hmap::Array *> p_arrays,
+        [&node, &hmin, &hmax, &range, &k](std::vector<hmap::Array *> p_arrays,
                               const hmap::TileRegion &)
         {
           auto [pa_out, pa_in] = unpack<2>(p_arrays);
           *pa_out = *pa_in;
 
           hmap::saturate(*pa_out,
-                         node.get_attr<RangeAttribute>("range")[0],
-                         node.get_attr<RangeAttribute>("range")[1],
+                         range[0],
+                         range[1],
                          hmin,
                          hmax,
-                         node.get_attr<FloatAttribute>("k_smoothing"));
+                         k);
         },
         node.cfg().cm_cpu);
 

--- a/docs/meta-migration/2026-07-09-assessment-and-design.md
+++ b/docs/meta-migration/2026-07-09-assessment-and-design.md
@@ -1,0 +1,255 @@
+# Meta Migration — Assessment & Design
+
+**Date:** 2026-07-09
+**Branch:** `feature/meta-migration` (purpose-built; all Meta work stays off day-to-day branches)
+**Status:** Assessment complete; design decisions partially locked; ready for detailed planning.
+
+## 1. Goal
+
+Migrate Hesiod's node attribute layer off `otto-link/Attributes` (and its vendored
+`QSliderX`) onto Otto's new `otto-link/Meta` framework, per Otto's Discord proposal:
+
+> Associate each `hesiod::BaseNode` with a `meta::ContainerGroup`. At minimum the
+> group holds one `meta::AttributeContainer` (replicating today's design). Nodes with
+> multiple parameter sets can hold several containers with one marked *current*, so a
+> single node can expose multiple "flavors" (e.g. one `Noise` node instead of
+> `Noise`/`NoiseFbm`/`NoiseIq`). Widget rendering is fully automated by Meta.
+
+This document records what we found assessing the design against the real codebase, the
+decisions taken, and the proposed shape of the full migration. Detailed sequencing is
+left to the implementation plan (writing-plans).
+
+## 2. The three layers Meta touches
+
+The proposal reads as one change but is really three separable concerns:
+
+1. **Storage** — `BaseNode`'s attribute map (`base_node.hpp:118`,
+   `std::map<std::string, std::unique_ptr<attr::AbstractAttribute>>` + parallel
+   `attr_ordered_key` vector) becomes a `meta::ContainerGroup`.
+2. **Widgets** — the attribute→Qt-widget layer (today entirely inside
+   `external/Attributes`, which vendors `QSliderX`) becomes `MetaUI/qt`.
+3. **Serialization** — the `.hsd` on-disk format, currently produced by
+   `attr::AbstractAttribute::json_to/from`, moves onto `meta`'s JSON.
+
+Storage and widgets are coupled: `MetaUI` renders directly from `meta` containers, so a
+node's panel must move to `MetaUI` the moment its storage moves to `meta`. Serialization
+is independent and is the sharpest risk (see §6).
+
+## 3. Coverage matrix — Hesiod's 15 attribute types → Meta
+
+Usage counts are `add_attr<T>` frequency across `Hesiod/src/model/nodes/nodes_function/`
+(304 files). ~96% of all usage falls in the clean-mapping group.
+
+### Clean 1:1 (8 types, ~96% of all usage)
+
+| Hesiod (`attr::`) | Uses | Meta equivalent |
+|---|---|---|
+| `FloatAttribute` | 825 | `Attribute<float>` + `SliderFloat` (`ui.log_scale`, `ui.plus_minus` supported) |
+| `BoolAttribute` | 197 | `Attribute<bool>` + Toggle/Checkbox |
+| `IntAttribute` | 100 | `Attribute<int>` + SliderInt/Input |
+| `SeedAttribute` | 73 | `presets::seed` (`Attribute<int>`) — see gap: randomize button |
+| `EnumAttribute` | 55 | `Attribute<int>` + `EnumComboBox` + `constraints.enum_items` (value→label pairs) |
+| `FilenameAttribute` | 14 | `Attribute<std::filesystem::path>` + OpenFile/SaveFile/Directory |
+| `ChoiceAttribute` | 13 | `Attribute<std::string>` + `constraints.allowed_values` ComboBox/ButtonGrid (runtime-mutable) |
+| `StringAttribute` | 7 | `Attribute<std::string>` |
+| `ColorAttribute` | 2 | `glm::vec4` + ColorPicker (Hesiod stores `array<float,4>` RGBA) |
+| `ColorGradientAttribute` | 1 | `meta::ColorGradient` + GradientEditor — structurally identical `Stop{position, rgba[4]}` + presets |
+| `VecFloatAttribute` / `ArrayAttribute` | 3 | `Attribute<std::vector<float>>` + CurveEditor |
+
+Enum note: Hesiod already holds every label→int map in `enum_mappings.hpp`; each
+`add_attr<EnumAttribute>` site passes one. Only `value`+`choice` hit disk, and the maps
+are re-injected at node construction — so **enums migrate cleanly**.
+
+### Genuine gaps (7 features, ~4% of usage but high value)
+
+| Hesiod feature | Uses | Meta gap | Candidate owner |
+|---|---|---|---|
+| `RangeAttribute` + **histogram callback** | 14 | `RangeBar` has no background histogram; runtime input-data→UI binding absent (`setup_histogram_for_range_slider.cpp`) | per-gap decision |
+| `CloudAttribute` + **background-image callback** | 2 | `PointsCanvas` has no heightmap preview behind it | per-gap decision |
+| `WaveNbAttribute` **linked/lock** | 31 | only `glm::vec2`+LinkedSliders; loses lock semantics | small custom widget |
+| **Grouped/nested settings** (`attr_ordered_key` groupbox pseudo-keys `_GROUPBOX_BEGIN_/_END_`, `_SEPARATOR_`, `_TEXT_`) | pervasive | Meta category system is **flat** ("Settings" root, `META_DEFAULT_CATEGORY_POLICY "flat"`); `collapsible_section` widget exists as a starting point | likely upstream to Meta |
+| **Tooltips** (`update_attributes_tool_tip`) | all nodes | no `tooltip`/`description` metadata key (only `label`) | likely upstream (add key) |
+| **Cross-attribute active-state bindings** (`island.cpp:120`, `cloud_random.cpp:46`, `set_is_active`/`save_initial_state`) | few | `ui.state` key exists but no dependency engine | Hesiod-side logic |
+| Seed **randomize button** | 73 | `presets::seed` renders a plain Input; Hesiod has a dedicated randomize widget | small custom widget or upstream |
+
+**Extensibility is the escape hatch:** Meta adds types via `AttributeTraits<T>` +
+`TypeName<T>` + a `WidgetRenderer<T>` specialization + a `typeid` branch, so every gap is
+closeable **without forking Meta core** — the only question per gap is Hesiod-side
+renderer vs upstream PR to Meta.
+
+## 4. What Meta gives us for free (net wins)
+
+Capabilities Hesiod hand-rolls or lacks today:
+
+- **Undo/redo** with slider-drag merging (`meta/undo_redo/`, `SetAttributeCommand<T>` with
+  `merge_with`). Hesiod has no attribute undo/redo today.
+- **Named snapshot / preset system** (`SnapshotManager`, `PresetComboBox` "Save preset…").
+- **Real type-driven attribute factory** (`attribute_factory.cpp`,
+  `register_builtin_types()`). Hesiod currently has *no* factory — the on-disk `"type"`
+  int is vestigial and types are reconstructed at node construction.
+- **FTXUI terminal backend** (`MetaUI/ftxui/`) — a bonus headless UI path.
+- **Per-attribute metadata is first-class** (each `meta::Attribute` is itself a
+  `MetaObject` carrying its own container of UI hints) — cleaner than the parallel
+  `attr_ordered_key` vector.
+
+## 5. Widget-layer swap surface (narrow)
+
+Confirmed: Hesiod owns almost none of the widget code.
+
+- `external/Attributes` owns the `AttributeType` model, the type→widget dispatch
+  (`get_attribute_widget`, `attributes_widget.cpp:45`), every concrete widget, and vendors
+  `QSliderX` as a **nested** submodule (`external/Attributes/.gitmodules`). Hesiod links
+  only `attributes` (`Hesiod/CMakeLists.txt:82`); QSliderX comes transitively. The only
+  direct QSliderX reference in Hesiod is a CSS comment (`apply_global_style.cpp:56`).
+- Hesiod owns only the thin wrapper `NodeAttributesWidget`
+  (`node_attributes_widget.cpp:208` builds `attr::AttributesWidget(...)`) plus the panel
+  host `NodeSettingsWidget` and a doc-gen usage (`node_factory.cpp:129`).
+
+Swap touchpoints in Hesiod (≈4): the `AttributesWidget` construction, the
+`value_changed`/`update_button_released` signal wiring → `GraphNode::update` (recompute),
+the CMake link, and the doc-gen screenshot path. Everything type-specific is replaced
+wholesale by `MetaUI/qt` — **provided** Meta covers the widget inventory + the §3 gaps.
+
+## 6. Serialization — the real risk
+
+Current `.hsd` (example `site/examples/Blend.hsd`): a flat per-node object; each attribute
+is `{ "type": <int>, "type_string": <str>, "label": <str>, "value": …, "vmin"/"vmax"/… }`
+(`abstract_attribute.cpp:34`, `float_attribute.cpp:41`). The **loader is tolerant**
+(`base_node.cpp:381`): missing key → keep default; extra key → ignored; parse error →
+logged, not fatal.
+
+The dangerous failure mode: if `meta`'s JSON shape differs, the per-attribute
+`json.contains(key)` probe misses on **every** attribute → each node loads as
+**all-defaults with no error**. Silent data loss, not a crash.
+
+The shape is pinned in **three independent places**, any of which breaks on a shape change:
+
+1. The `attr::AttributeType` enum ints written as `"type"` (`abstract_attribute.hpp:20-42`,
+   explicitly "DO NOT change the order").
+2. The flat per-node attribute layout assumed by the loader.
+3. The **Python `hsd` toolkit** — `scripts/hsd/catalog.py` `TYPE_MAP` hard-codes the numeric
+   codes; `scripts/hsd/params.py` emits the literal envelope; `scripts/hsd/data/*.json`
+   duplicate enum ints — plus ~150 `site/examples/*.hsd` and the `tests/hsd/` suite.
+
+The `"Hesiod version"` field is the natural hook for a version-gated reader.
+
+**Decision (open, resolved in planning):** the PoC node (§8, Phase B) prototypes **both**
+(a) an adapter that keeps the existing `.hsd` shape, and (b) Meta's native shape with a
+version-gated reader. We measure the real JSON diff and toolkit blast radius, then lock the
+choice. Guarding the silent-all-defaults mode (fail loud on shape mismatch) is mandatory
+either way.
+
+## 7. Node architecture & the multi-flavor question
+
+- Registration is a **hand-maintained inventory** (~250 entries, `node_factory.cpp`
+  `get_node_inventory()`) + a giant `switch`/`SETUP_NODE` macro dispatching to
+  `setup_X_node`/`compute_X_node` free-function pairs, one file per node.
+- **No container abstraction exists** — `ContainerGroup` is genuinely new plumbing.
+- Compute reads attrs via `get_attr<T>("key")` (`base_node.hpp:94`).
+- The Noise family maps cleanly to flavors (shared ports `dx,dy,[control],envelope→out`,
+  overlapping core attrs; precedents: `default_noise.cpp` shared setup, `NoiseJordan`
+  reusing `noise_iq`). Friction: plain `Noise` has fewer attrs + no `control` port;
+  `NoiseParberry` drops `noise_type`; output port name is inconsistent (`out` vs `output`).
+
+**Decision (locked): node-merging is DEFERRED.** The migration gives each `BaseNode` a
+`ContainerGroup` with exactly **one** container — a behavior-preserving storage swap. No
+node identity changes, so the 7-point catalog/docs blast radius stays untouched:
+(1) inventory+switch, (2) `graph_node_widget.cpp` + `node_library_widget.cpp` catalogs,
+(3) `dump_node_documentation_stub`, (4) Python doc scripts, (5) per-node `_settings.png`
+screenshots, (6) per-node `data/examples/*.hsd`, (7) runtime docs load. The
+`ContainerGroup` layer should be built **merge-ready** (single-container today, multi
+tomorrow) but merging itself is a separate future project.
+
+## 8. Proposed migration phasing (for the plan)
+
+High-level only; writing-plans owns the detail.
+
+- **Phase A — Foundations.** Add `otto-link/Meta` as a submodule (`external/Meta`), wire
+  CMake for `meta` core + `MetaUI/qt`, building **alongside** `Attributes` during
+  transition. Establish the branch/submodule-pin strategy (§9).
+- **Phase B — Vertical PoC (de-risk).** Migrate ONE node (`Noise`) fully: `ContainerGroup`
+  (1 container) storage + `MetaUI/qt` panel + `.hsd` round-trip. Prototype **both**
+  serialization strategies → **lock the §6 decision**. Validate a compatibility facade for
+  `add_attr/get_attr` so the 304 node files change minimally. Deliverable: findings +
+  decisions to share with Otto.
+- **Phase C — Storage/widget bulk migration.** Roll the facade across all node files;
+  each node moves storage→`meta` and panel→`MetaUI` together. Resolve §3 gaps **per-gap**
+  (Hesiod-side renderer vs upstream to Meta) as they're hit.
+- **Phase D — Remove `Attributes` + `QSliderX`.** Once every node is on `meta`, drop the
+  `external/Attributes` submodule and the CMake link in one cut; delete the thin wrapper.
+- **Phase E — Adopt the free wins.** Wire undo/redo + preset/snapshot into the GUI.
+- **Later (separate project) — Node-merging.** Multi-container flavors + the 7-point
+  catalog/docs reconciliation.
+
+The compatibility-facade choice in Phase B (keep `BaseNode::add_attr<T>`/`get_attr<T>`
+signatures, back them with `meta`) vs a bulk codemod of 304 files is a key sub-decision to
+settle in the PoC — facade is the lower-risk default.
+
+## 9. Branch & submodule strategy
+
+All work on purpose-built branches, isolated from Hesiod's day-to-day:
+
+- **Hesiod:** `feature/meta-migration` (this branch), off `upstream/dev`. Later phases may
+  fork per-phase feature branches off it.
+- **Meta:** pin the `external/Meta` submodule to a fixed commit; if Hesiod needs Meta
+  changes (gap widgets, tooltip key, nested groups), do them on a Meta feature branch and
+  bump the pin — never depend on Meta `main` moving under us.
+- No PR/merge to `dev` without explicit request (standing rule). No CI on these branches.
+
+## 10. Open items to resolve in planning
+
+1. **Serialization shape** — adapter vs native; prototype both in Phase B (§6).
+2. **Per-gap ownership** — RESOLVED (2026-07-09, Otto issue #15): all gap work lands in
+   Meta. Two genuinely-new Meta capabilities remain — the `ui.data_provider` hook (closes
+   G1 range-histogram + G2 cloud-background; Meta-neutral return struct) and the
+   `ui.tooltip` key (G6). G3 (`ui.locked_xy`) and G5 (`ui.category` + CP_TREE) already exist;
+   G4 dropped; G7 reset uses `SnapshotManager` default state. See the gaps doc RESOLUTION
+   table. These two Meta capabilities become explicit tasks in the plan.
+3. **Facade vs codemod** — RESOLVED (Phase B PoC, §11): favour a **compatibility facade**.
+4. **Meta build integration specifics** — dependency reconciliation (nlohmann_json, spdlog,
+   glm already in Hesiod; `META_ENABLE_GLM_TYPES`, `META_ENABLE_COLOR_GRADIENT_TYPES` flags).
+5. **Coordination with Otto** — which gaps Otto wants upstreamed vs kept Hesiod-side; the
+   Phase B findings are the artifact to drive that conversation.
+
+## 11. Phase B PoC outcomes & decisions (2026-07-10)
+
+The vertical PoC (Meta submodule + build + Noise node migrated end-to-end) is implemented on
+`feature/meta-migration` (commits `93e42ed3`…`b2659356`). Meta core + `meta_qt` compile and
+link in Hesiod's toolchain; the Noise node stores its params in a `meta::ContainerGroup`,
+auto-renders via `meta::qt::ContainerGroupWidget`, recomputes on edit, and serializes.
+
+**Serialization — DECISION: native `_meta` shape (not adapter).** `BaseNode::json_to/json_from`
+serialize a meta-backed node's container under a `"_meta"` key with a fail-loud guard (absent
+`_meta` on a meta node logs an error rather than silently defaulting). The adapter (reproduce
+the legacy flat shape) was rejected: Meta stores `noise_type`/`seed` as plain `int` and `kw` as
+`glm::vec2`, but legacy `.hsd` tags them semantically (Enumeration / "Random seed number" /
+Wavenumber). Meta's value-type does not carry Hesiod's semantic attribute type, so an adapter
+cannot faithfully reproduce legacy per-attribute tags without a bespoke per-attribute semantic
+map. **Full-migration implication:** the Python `hsd` toolkit + ~150 `site/examples/*.hsd` assume
+the legacy shape; a meta-native world needs the toolkit regenerated (or a one-time old→new
+translator) and the `"Hesiod version"` field used to gate old-file reads. This is a whole
+workstream, tracked for the migration phase.
+
+**Facade vs codemod — DECISION: compatibility facade.** Authoring the Noise node directly against
+Meta cost ~5–8 lines per attribute (one `add<T>` + several `metadata().try_add(...)` calls) vs the
+legacy 1-line `add_attr<T>(key,label,def,min,max,...)`. Across 304 node files and ~1300 attribute
+declarations (825 Float alone), a direct codemod would balloon the node sources and churn every
+file. A facade that keeps `BaseNode::add_attr<LegacyType>(...)` signatures and internally maps
+each legacy attribute type → (`container.add<value_t>` + the right `ui.*`/`constraints.*` metadata)
+localises the translation to one shim, keeps node files ~1 line/attr, and makes the bulk migration
+mechanical. The 8 clean types (Float/Bool/Int/Seed/Enum/String/Filename/Color, ~96% of usage) map
+directly; the tricky types (Range+histogram, Cloud, WaveNb, etc.) route through the same shim once
+their Meta capabilities land (`ui.data_provider` etc., issue #15).
+
+**Widget sizing — FINDING (deferred to Meta-editing phase).** Meta's `SliderFloat`/`LinkedSliders`
+set a computed `minimumWidth` that, for the paired-slider `glm::vec2` (`kw`), exceeds Hesiod's
+settings panel — which is hard-capped at 360px (`node_settings_widget.cpp:28-29`, `// TODO fix
+this`) with horizontal scroll off. The widest widget forces the container wide, so all inputs clip.
+Fix belongs with the Meta-editing phase: make Meta widgets shrink to narrow panels and/or fix the
+360px cap. (Unrelated: empty toolbar icons launching from `build/bin` are the `qtsvg` plugin-path
+launch-env issue, not Meta.)
+
+**Environment note.** A nixpkgs Qt bump (6.11.0→6.11.1) mid-work left `build/` configured against
+6.11.0 (stale `CMakeCache`/RUNPATH), causing a `Qt_6_PRIVATE_API` symbol skew at runtime. Fix: `rm
+-rf build` + fresh configure under the devshell → coherent 6.11.1 binary. Full rebuilds must cap
+parallelism (`-j4`) and run detached — unbounded `-j` OOMs and killed the terminal server.

--- a/docs/meta-migration/2026-07-09-gaps-discussion.md
+++ b/docs/meta-migration/2026-07-09-gaps-discussion.md
@@ -1,0 +1,300 @@
+# Meta Migration — The Genuine Gaps (discussion agenda for Otto)
+
+**Date:** 2026-07-09
+**Companion to:** `2026-07-09-meta-migration-design.md`
+**Purpose:** A per-point agenda for deciding, with Otto, how each capability that
+`otto-link/Attributes` + `QSliderX` provide today but `otto-link/Meta` does not yet, gets
+closed — Hesiod-side extension vs upstream into Meta. Everything else (~96% of attribute
+usage) maps 1:1 and is out of scope here.
+
+For each gap: **what Hesiod does today** (with evidence), **why it matters**, **what Meta
+offers now**, **the precise shortfall**, **options**, and **the question for Otto**.
+
+---
+
+## RESOLUTION (2026-07-09, per Otto on issue #15)
+
+Otto's response collapsed the gap list. Corrected status — **all remaining work lands in
+Meta** (the migration moves the attribute + widget system into Meta):
+
+| # | Gap | Resolution |
+|---|---|---|
+| G1 | Range + live histogram | **Build in Meta:** a non-serialized `std::function` on attribute metadata under `ui.data_provider`, consumed by the RangeBar renderer. |
+| G2 | Cloud + heightmap background | **Same `ui.data_provider` mechanism** — consumed by the PointsCanvas renderer as a background image. Return type is a **Meta-neutral struct** (each backend converts; core stays Qt-free so ftxui isn't boxed out). |
+| G3 | Wavenumber X/Y lock | **Already in Meta** — `ui.locked_xy` (`glm_vec2.inl:29`). Just set it. |
+| G4 | Seed randomize button | **Dropped** — `±1` stepper is functionally equivalent; keep Hesiod's node-level `reseed()` for bulk. |
+| G5 | Nested/grouped settings | **Already in Meta** — `ui.category` repertory paths + CP_FLAT/CP_MERGED/CP_TREE + regex default-collapse. Migration expresses old `_GROUPBOX_*` as `ui.category` paths. |
+| G6 | Rich tooltips | **Build in Meta:** a `ui.tooltip` key applied centrally in the base render path (HTML/rich text). |
+| G7 | Attribute active-state + reset | Active toggle via the **`ui.state`** metadata key (coherent with `VectorEditor`/`LinkedSliders`; replaces the ad-hoc `{-1,0}` RangeBar sentinel, which Otto will retire). Lock via `locked_xy`. Reset uses `SnapshotManager`: store a `default` state right after node setup; user resets to it (replaces the old per-attribute `save_initial_state()`). |
+
+**Net genuinely-new Meta capabilities: two** — the `ui.data_provider` hook (G1+G2) and the
+`ui.tooltip` key (G6). Everything else already exists or is a settled idiom. The sections
+below are retained for the original reasoning/evidence.
+
+---
+
+## Cross-cutting theme (read first)
+
+Two of the gaps below (G1 Range-histogram, G2 Cloud-background) are the same architectural
+question wearing two hats:
+
+> **Can a `MetaUI` widget display host-supplied, runtime-computed data behind/around the
+> control — data the widget itself cannot know how to produce?**
+
+In Hesiod the data is derived from a node's *input heightmap* at edit time (a histogram, a
+colorized thumbnail). The attribute has no access to the graph; the node injects a callback.
+`attr::` models this as a `std::function` stored on the attribute
+(`set_histogram_fct`, `set_background_image_fct`). If Meta grows one general mechanism —
+"a widget may be given a host callback that returns render data" — both gaps close together,
+and it becomes the extension point for future previews (colormap bars, curve-over-heightmap,
+etc.). That general hook is the single most valuable thing to align on with Otto. G3–G7 are
+smaller and mostly independent.
+
+---
+
+## G1 — Range slider with live input histogram
+
+**Uses:** `RangeAttribute` ×14, plus the remap pattern is pervasive across post-process nodes.
+
+**What Hesiod does today.**
+`RangeAttribute` (`external/Attributes/.../range_attribute.hpp:18`) stores `glm::vec2`
+(min,max) + `vmin/vmax` bounds + an `is_active` flag + a histogram provider:
+```cpp
+std::function<PairVec()> histogram_fct;   // PairVec = pair<vector<float> values, vector<float> counts>
+void set_histogram_fct(std::function<PairVec()>);
+void set_autorange(bool);
+```
+Hesiod wires it per-node (`setup_histogram_for_range_attribute`,
+`setup_histogram_for_range_slider.cpp:17`): a lambda reads the node's input port
+(`node.get_value_ref<hmap::VirtualArray>(port_id)`), renders the heightmap to a 256×256
+array, bins it into a histogram, and returns it. The range widget draws that histogram
+behind the two handles, so the user sets the min/max against the actual data distribution.
+`set_autorange(true)` lets it snap the handles to the data range.
+
+**Why it matters.** Choosing a remap/clamp range blind (no histogram) is a real usability
+regression — this is one of Hesiod's signature interactions.
+
+**What Meta offers now.** `glm::vec2` + `widget_type="RangeBar"` (`range_bar` widget). It
+renders two handles over a plain track — **no background data, no autorange, no host
+callback hook**.
+
+**Shortfall.** (a) no channel to feed a per-instance histogram into the widget; (b) no
+autorange; (c) `is_active` enable/disable of the whole attribute (see G7).
+
+**Options.**
+- **A (Hesiod-side):** subclass/extend `RangeBar` in a Hesiod MetaUI renderer that accepts a
+  `std::function<PairVec()>` via attribute metadata; register a `WidgetRenderer` branch.
+  Needs Meta to expose the widget base + a metadata slot for a callback (see the general
+  hook above).
+- **B (upstream):** Meta's `RangeBar` grows an optional "background series" data source +
+  autorange, fed through the general host-callback mechanism.
+
+**Question for Otto.** Do you want the generic host-callback-into-widget mechanism in Meta
+(then histogram is just a consumer), or should Hesiod carry a bespoke range widget? Is
+storing a `std::function` on an attribute's metadata acceptable in Meta's model, or do you
+prefer a different binding (e.g. the widget pulls from a registered provider keyed by
+attribute name)?
+
+---
+
+## G2 — Point-cloud editor with heightmap background
+
+**Uses:** `CloudAttribute` ×2 (Cloud, CloudRandom-style nodes), plus latent demand for path/point editors.
+
+**What Hesiod does today.**
+`CloudAttribute` stores `std::vector<glm::vec3>` (x,y,value points) + a background provider:
+```cpp
+void set_background_image_fct(std::function<QImage()>);
+```
+Wired per-node (`setup_background_image_for_cloud_attribute.cpp:18`): the lambda colorizes
+the node's input heightmap (MAGMA, 256×256) into a `QImage` drawn behind the point canvas,
+so points are placed against the terrain.
+
+**Why it matters.** Placing control points/clouds without seeing the terrain underneath is
+guesswork.
+
+**What Meta offers now.** `std::vector<glm::vec3>` + `widget_type="PointsEditor"`
+(`points_canvas`, with Clear/Randomize/From-CSV, min/max x/y, z-step, closed flag). **No
+background image hook.**
+
+**Shortfall.** Same root cause as G1 — no channel to inject a host-computed background
+(`QImage`) into the canvas.
+
+**Options.** Same A/B as G1; ideally both share the general host-callback hook (G1 returns a
+data series, G2 returns an image).
+
+**Question for Otto.** Should the general hook be typed per widget (series vs image), or a
+single `std::any`/variant the renderer interprets? Does Meta want a Qt dependency (`QImage`)
+in the callback signature, or a Meta-neutral image struct that the Qt backend converts?
+
+---
+
+## G3 — Wavenumber attribute with X/Y lock
+
+**Uses:** `WaveNbAttribute` ×31 (very common — every coherent-noise primitive).
+
+**What Hesiod does today.**
+`WaveNbAttribute` (`wave_nb_attribute.hpp:16`) stores `glm::vec2` (kx,ky) + `vmin/vmax` + a
+`link_xy` bool. When linked, editing one component drives the other so the frequency stays
+isotropic; unlinking allows anisotropic `kw`. Its widget exposes the lock toggle.
+
+**Why it matters.** 31 uses; isotropic frequency is the common case and the lock makes it
+one-drag. Losing it means every noise node forces two-field editing.
+
+**What Meta offers now.** `glm::vec2` + `LinkedSliders` widget, and a `constraints.aspect_ratio`
+key exists — but there is **no lock *toggle*** (runtime link on/off) and no `kw` semantics
+(the field is generic 2D).
+
+**Shortfall.** No user-toggleable X/Y link; `aspect_ratio` is a fixed constraint, not a
+switch the user flips.
+
+**Options.**
+- **A (Hesiod-side):** a small `WidgetRenderer` for `glm::vec2` gated on a
+  `ui.widget_type="Wavenumber"` hint + a `ui.link_xy` metadata bool, reusing `LinkedSliders`.
+- **B (upstream):** add a "linkable" mode to Meta's `LinkedSliders` driven by a metadata
+  bool the user can toggle.
+
+**Question for Otto.** Is a toggleable link something you'd take into `LinkedSliders`
+generically (useful beyond terrain), or is `kw` niche enough to keep Hesiod-side?
+
+---
+
+## G4 — Seed field with randomize button
+
+**Uses:** `SeedAttribute` ×73 (every stochastic node).
+
+**What Hesiod does today.** `SeedAttribute` (`seed_attribute.hpp`) is a `uint`, but its widget
+adds a dedicated "randomize" (dice) button that rolls a new seed in place. Hesiod also has a
+node-level `reseed()`.
+
+**What Meta offers now.** `presets::seed` = `Attribute<int>` with `widget_type="Input"`
+(min 0, max INT_MAX). Plain spinbox — **no randomize button.**
+
+**Shortfall.** No one-click reseed at the widget.
+
+**Options.**
+- **A (Hesiod-side):** a tiny renderer variant `widget_type="Seed"` = int spinbox + dice
+  button that writes a random value through the normal set path (so undo/redo still works).
+- **B (upstream):** extend `presets::seed` / add a `SeedWidget` to MetaUI.
+
+**Question for Otto.** Want a first-class `Seed` widget in MetaUI (seeds are common in
+generative tools), or leave it to Hesiod? Note: the randomize must go through Meta's
+`SetAttributeCommand` so it participates in undo/redo — worth confirming the write path.
+
+---
+
+## G5 — Nested / grouped settings layout
+
+**Uses:** pervasive — many nodes group their attributes; some have several groups
+(e.g. `flow_simulation.cpp:71` has *Water Setup / Post-filter / Solver*).
+
+**What Hesiod does today.** Grouping rides on the ordered-key list via pseudo-keys:
+`set_attr_ordered_key({"_GROUPBOX_BEGIN_<title>", "attrA", "attrB", "_GROUPBOX_END_", ...})`,
+also `_SEPARATOR_`, `_TEXT_`, `_SEPARATOR_TEXT_` (`attributes_widget.cpp:150-222`). Renders as
+titled group boxes in the settings panel.
+
+**What Meta offers now.** The category system is explicitly **flat**
+(`META_DEFAULT_CATEGORY_POLICY "flat"`, root "Settings"). There is a `constraints`/`ui.category`
+key and a `collapsible_section` widget exists, but no nested-group layout policy driving them.
+
+**Shortfall.** No structured grouping (titled boxes / collapsible sections / tabs) from
+metadata. A flat migration would dump every node's attributes into one ungrouped list — a
+visible UX regression on complex nodes.
+
+**Options.**
+- **A (Hesiod-side):** translate the `_GROUPBOX_*` convention into a Hesiod-built panel
+  assembler that groups by a `ui.category` value and uses `collapsible_section`. Feasible but
+  re-implements layout Meta arguably should own.
+- **B (upstream):** Meta gains a "grouped" category policy: `ui.category` (or a `ui.group`
+  key) drives titled/collapsible sections in `container_group_widget`.
+
+**Recommendation.** Leans **upstream** — grouping is generic UI, not terrain-specific, and
+`collapsible_section` is already half of it.
+
+**Question for Otto.** Is a non-flat category policy on your roadmap? If so, what's the key
+model — reuse `ui.category` with a policy switch, or a dedicated nesting key? This also
+affects the migration of ~all `set_attr_ordered_key` calls, so it's worth settling early.
+
+---
+
+## G6 — Rich attribute tooltips from node docs
+
+**Uses:** all nodes (`update_attributes_tool_tip`, `base_node.cpp:564`).
+
+**What Hesiod does today.** After construction, Hesiod walks each attribute and, if the node's
+documentation JSON has a `parameters.<key>.description`, builds an HTML tooltip
+(bold label + secondary-color wrapped description) and calls
+`sp_attr->set_description(html)` (`base_node.cpp:589`). `attr::AbstractAttribute` thus carries a
+`description` that the widget shows on hover.
+
+**What Meta offers now.** Metadata keys include `ui.label` but **no `tooltip`/`description`/`help`
+key**, and no evidence the renderers show a hover tooltip.
+
+**Shortfall.** No per-attribute help text channel; in-app parameter help disappears.
+
+**Options.**
+- **A (Hesiod-side):** store the HTML under an ad-hoc metadata key and have a Hesiod renderer
+  set the Qt `toolTip`. Works, but every widget type needs the wiring.
+- **B (upstream):** add a `ui.tooltip` (or `ui.description`) metadata key that the base
+  renderer applies as the widget tooltip for all types.
+
+**Recommendation.** **Upstream** — trivial, generic, one key + one `setToolTip` in the base
+render path.
+
+**Question for Otto.** Any objection to a standard `ui.tooltip` key applied centrally? Rich
+text (HTML) or plain? Hesiod currently feeds HTML.
+
+---
+
+## G7 — Attribute active-state toggle + initial-state reset
+
+**Uses:** a handful but load-bearing (e.g. `island.cpp:121`, `cloud_random.cpp:46`).
+
+**What Hesiod does today.** `RangeAttribute` has an `is_active` flag. Nodes toggle it and
+snapshot the baseline:
+```cpp
+node.get_attr_ref<RangeAttribute>("post_remap")->set_is_active(false);
+node.get_attr_ref<RangeAttribute>("post_remap")->save_initial_state();   // island.cpp:121
+```
+and compute branches on it:
+```cpp
+if (node.get_attr_ref<RangeAttribute>("remap")->get_is_active())         // cloud_random.cpp:46
+    p_out->remap_values(...);
+```
+So an attribute can be present-but-disabled (checkbox-gated), with a stored initial state used
+for reset-to-default. `save_initial_state()` exists on the `attr::` base for all attributes.
+
+**What Meta offers now.** A `ui.state` metadata key exists (no dependency engine behind it), and
+`SnapshotManager` can name/restore JSON snapshots at the container level. But there is **no
+per-attribute `is_active`/enabled concept** and no per-attribute "initial state" baseline.
+
+**Shortfall.** (a) No "enabled" bit on an attribute that both the UI (grey out) and compute
+(`if active`) read; (b) no per-attribute initial-state to reset to.
+
+**Options.**
+- **A (Hesiod-side):** model `is_active` as a companion `Attribute<bool>` per gated attribute,
+  and use `SnapshotManager` for reset. Changes the compute-side idiom (`get_is_active()` →
+  read a sibling bool) across the affected nodes.
+- **B (upstream):** Meta adds an optional `enabled` bit + initial-state to `AbstractAttribute`,
+  matching `attr::`'s `is_active` + `save_initial_state()`.
+
+**Question for Otto.** Do you consider enable/disable + reset-to-initial a core attribute
+concern (as `attr::` did), or should hosts compose it from a sibling bool + snapshots? This
+decides whether ~a-dozen node compute functions change idiom.
+
+---
+
+## Summary table
+
+| # | Gap | Uses | Nearest Meta primitive | Leaning |
+|---|---|---|---|---|
+| G1 | Range + live histogram | 14 | RangeBar (no data hook) | **general host-callback hook** (upstream) |
+| G2 | Cloud + heightmap background | 2 | PointsEditor (no image hook) | same hook as G1 |
+| G3 | Wavenumber X/Y lock toggle | 31 | LinkedSliders + aspect_ratio | either; ask Otto |
+| G4 | Seed randomize button | 73 | presets::seed (Input) | small; either |
+| G5 | Nested/grouped settings | pervasive | flat category + collapsible_section | **upstream** |
+| G6 | Rich attribute tooltips | all | no tooltip key | **upstream** (trivial) |
+| G7 | Attribute active-state + reset | ~dozen | ui.state + SnapshotManager | ask Otto (idiom-defining) |
+
+**The one decision that unlocks the most:** the **general host-callback-into-widget hook**
+(G1+G2). Settle that with Otto first; G3–G7 are smaller and can be triaged per-point.

--- a/docs/meta-migration/2026-07-09-phase-ab-plan.md
+++ b/docs/meta-migration/2026-07-09-phase-ab-plan.md
@@ -1,0 +1,508 @@
+# Meta Migration — Phase A + B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring `otto-link/Meta` into Hesiod's build and migrate the single `Noise` node end-to-end onto it (storage, auto-rendered widgets, `.hsd` round-trip) as an isolated vertical slice that de-risks the full migration and settles the serialization approach.
+
+**Architecture:** Meta is added as a submodule and built alongside the existing `Attributes` library (both present during transition). `BaseNode` gains a `meta::ContainerGroup` *alongside* its current `attr` map, opt-in per node via a flag. Only `Noise` flips the flag: its parameters live in a `meta::AttributeContainer`, its panel is rendered by `meta_qt`, and its serialization is prototyped in two shapes to pick the format. Every other node is untouched and keeps using `Attributes`.
+
+**Tech Stack:** C++20, CMake ≥3.22, Qt6 (Core, Widgets), nlohmann_json, spdlog, glm — all already present in Hesiod. Meta core (`meta`), Meta Qt backend (`meta_qt`).
+
+## Global Constraints
+
+- All Phase A/B work happens on the single Hesiod branch `feature/meta-migration` (off `upstream/dev`), fully isolated — it never merges to Hesiod `dev`/`main` until a deliberate cutover. No CI on this branch. See the **Branch Strategy** section below.
+- Phase A/B **only consumes** Meta — it does not modify it. The `external/Meta` submodule is pinned to a **frozen commit SHA** (immutable; cannot drift). No Meta branch is needed until the later phase that first edits Meta.
+- Meta CMake options for Hesiod's build: `META_ENABLE_QT_UI=ON`, `META_ENABLE_GLM_TYPES=ON`, `META_ENABLE_COLOR_GRADIENT_TYPES=ON`, `META_ENABLE_FTXUI_UI=OFF`, `META_ENABLE_TESTS=OFF`.
+- Meta library targets: core = `meta` (STATIC, public include dir `Meta/include`), Qt backend = `meta_qt` (links `Qt6::Core`, `Qt6::Widgets`; pulls in `MetaUI/common`).
+- The migration is behavior-preserving: one `AttributeContainer` per node's `ContainerGroup`. No node identities change. Node-merging is out of scope.
+- Otto's gap resolutions (issue #15) are authoritative: `kw` uses `ui.locked_xy`; grouping uses `ui.category` repertory paths (not `_GROUPBOX_*`); reset uses a `SnapshotManager` `default` state; no seed randomize widget. `ui.data_provider`/`ui.tooltip` are NOT needed by the Noise PoC.
+- Build env quirks (this machine): Qt6 via Nix; run the GUI from the `data/` dir with `qtsvg` on `QT_PLUGIN_PATH`; if a wide recompile hits `qwebenginedownloadrequest.h`, add the base include via `NIX_CFLAGS_COMPILE`. The user builds and runs the GUI and pastes output — GUI verification steps are handed to the user.
+- Verification model: this codebase has no per-node unit-test harness. Tasks verify by (a) a successful build/link, (b) a headless `.hsd` round-trip via the CLI where possible, and (c) explicit user-run GUI checks. TDD applies where a headless test is feasible (Task B4).
+
+---
+
+## Phase A — Foundations (build integration)
+
+### Task A1: Add Meta as a submodule (frozen pin)
+
+**Files:**
+- Modify: `.gitmodules`
+- Create: `external/Meta` (submodule)
+
+**Interfaces:**
+- Produces: the `external/Meta` source tree pinned to a frozen commit SHA, containing `Meta/` (core) and `MetaUI/qt/` (Qt backend). Read-only for this plan — no Meta branch (see Branch Strategy).
+
+- [ ] **Step 1: Confirm you are on Hesiod's branch**
+
+Run:
+```bash
+cd /home/barrulus/dev/Hesiod
+git branch --show-current
+```
+Expected: `feature/meta-migration`. If not, `git switch feature/meta-migration` first.
+
+- [ ] **Step 2: Add the submodule (pins to current Meta HEAD as a frozen SHA)**
+
+```bash
+git submodule add git@github.com:otto-link/Meta.git external/Meta
+```
+
+- [ ] **Step 3: Verify the expected layout is present**
+
+Run:
+```bash
+ls external/Meta/Meta/include/meta/core/container_group.hpp external/Meta/MetaUI/qt/CMakeLists.txt external/Meta/CMakeLists.txt
+```
+Expected: all three paths listed (no "No such file").
+
+- [ ] **Step 4: Record the pinned commit**
+
+Run:
+```bash
+git submodule status external/Meta
+```
+Expected: a line beginning with the pinned SHA and `external/Meta`. Note the SHA in the commit message (this is the frozen base; a Meta branch, if later needed, is cut from it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .gitmodules external/Meta
+git commit -m "build(meta): add otto-link/Meta submodule (frozen pin <SHA>)"
+```
+
+### Task A2: Wire Meta into the CMake build and prove it links
+
+**Files:**
+- Modify: `external/CMakeLists.txt` (after the `Attributes` block, ~line 22)
+- Modify: `Hesiod/CMakeLists.txt` (the `target_link_libraries(...)` block at line 71, add near the `attributes` entry at line 82)
+- Modify: `Hesiod/src/main.cpp` (temporary smoke use — reverted in Step 6)
+
+**Interfaces:**
+- Consumes: the `external/Meta` tree from Task A1.
+- Produces: `meta` and `meta_qt` as link targets available to the `hesiod` target; Hesiod builds and links against Meta.
+
+- [ ] **Step 1: Add Meta to the external build with the required options**
+
+In `external/CMakeLists.txt`, after the `Attributes` block (the two lines `set(ATTRIBUTES_ENABLE_TESTS OFF)` / `add_subdirectory(Attributes)`), add:
+
+```cmake
+# Meta (transitional: built alongside Attributes)
+set(META_ENABLE_TESTS OFF)
+set(META_ENABLE_GLM_TYPES ON)
+set(META_ENABLE_COLOR_GRADIENT_TYPES ON)
+set(META_ENABLE_QT_UI ON)
+set(META_ENABLE_FTXUI_UI OFF)
+add_subdirectory(Meta)
+```
+
+- [ ] **Step 2: Link Meta into the Hesiod target**
+
+In `Hesiod/CMakeLists.txt`, in the `target_link_libraries(` block, add `meta` and `meta_qt` adjacent to the existing `attributes` entry (line 82):
+
+```cmake
+          attributes
+          meta
+          meta_qt
+```
+
+- [ ] **Step 3: Add a temporary smoke use to force a real link**
+
+In `Hesiod/src/main.cpp`, near the top of `main()`, add (temporarily):
+
+```cpp
+#include "meta/core/attribute_container.hpp"
+// ... inside main(), first lines:
+{
+  meta::AttributeContainer smoke;
+  smoke.add<float>("smoke", 1.0f);
+  spdlog::info("[meta smoke] container size = {}", smoke.size());
+}
+```
+
+- [ ] **Step 4: Configure and build**
+
+Run (from the repo's build dir; use the project's usual configure flags):
+```bash
+cmake -B build -S . && cmake --build build -j --target hesiod 2>&1 | tail -30
+```
+Expected: build completes; link succeeds; no unresolved `meta::` symbols. (If a wide recompile hits `qwebenginedownloadrequest.h`, set `NIX_CFLAGS_COMPILE` per the Global Constraints note and rebuild.)
+
+- [ ] **Step 5: Run and confirm the smoke line**
+
+Have the user launch the built binary and confirm the log line `[meta smoke] container size = 1` appears at startup. Expected: line present → Meta core is linked and functional.
+
+- [ ] **Step 6: Revert the smoke use, keep the build wiring**
+
+Remove the temporary block and include from `Hesiod/src/main.cpp` (Step 3). Rebuild to confirm still green:
+```bash
+cmake --build build -j --target hesiod 2>&1 | tail -5
+```
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add external/CMakeLists.txt Hesiod/CMakeLists.txt Hesiod/src/main.cpp
+git commit -m "build(meta): compile and link meta + meta_qt alongside Attributes"
+```
+
+---
+
+## Phase B — Vertical PoC on the Noise node
+
+### Task B1: Add an opt-in `meta::ContainerGroup` to BaseNode
+
+**Files:**
+- Modify: `Hesiod/include/hesiod/model/nodes/base_node.hpp` (add member + accessors near the attr API, lines 87-118)
+- Modify: `Hesiod/src/model/nodes/base_node.cpp` (accessor definitions)
+
+**Interfaces:**
+- Consumes: `meta::ContainerGroup` from Task A1/A2.
+- Produces:
+  - `bool BaseNode::uses_meta() const;`
+  - `meta::ContainerGroup &BaseNode::meta_group();` (creates the group + a `"main"` container on first use, sets it current, flips the flag)
+  - `const meta::ContainerGroup &BaseNode::meta_group() const;`
+  These let a single node opt into Meta storage while all others keep the `attr` map.
+
+- [ ] **Step 1: Add the member and accessors to the header**
+
+In `base_node.hpp`, add the include `#include "meta/core/container_group.hpp"` near the `attributes/abstract_attribute.hpp` include (line 14). In the `private:` members (after line 118) add:
+
+```cpp
+  std::unique_ptr<meta::ContainerGroup> meta_group_; // opt-in Meta storage (nullptr = legacy attr map)
+```
+
+In the public Attribute-Management section (near line 106) declare:
+
+```cpp
+  bool                       uses_meta() const;
+  meta::ContainerGroup      &meta_group();       // lazily creates group + "main" container
+  const meta::ContainerGroup &meta_group() const;
+```
+
+- [ ] **Step 2: Define the accessors**
+
+In `base_node.cpp` add:
+
+```cpp
+bool BaseNode::uses_meta() const { return this->meta_group_ != nullptr; }
+
+meta::ContainerGroup &BaseNode::meta_group()
+{
+  if (!this->meta_group_)
+  {
+    this->meta_group_ = std::make_unique<meta::ContainerGroup>();
+    this->meta_group_->add("main");
+    this->meta_group_->set_current("main");
+  }
+  return *this->meta_group_;
+}
+
+const meta::ContainerGroup &BaseNode::meta_group() const { return *this->meta_group_; }
+```
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+cmake --build build -j --target hesiod 2>&1 | tail -10
+```
+Expected: builds clean (no node uses the new path yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Hesiod/include/hesiod/model/nodes/base_node.hpp Hesiod/src/model/nodes/base_node.cpp
+git commit -m "feat(meta): add opt-in ContainerGroup storage to BaseNode"
+```
+
+### Task B2: Author the Noise node's parameters against Meta
+
+**Files:**
+- Modify: `Hesiod/src/model/nodes/nodes_function/noise.cpp` (setup + compute, whole file)
+
+**Interfaces:**
+- Consumes: `BaseNode::meta_group()` (Task B1); `meta::AttributeContainer::add<T>`, `try_add`, `value<T>`; `meta::Attribute<T>::metadata().try_add(key, value)`; metadata keys from `meta/metadata/keys.hpp` (`ui.widget_type`, `ui.category`, `constraints.min`, `constraints.max`, `constraints.enum_items`, plus ad-hoc `ui.locked_xy`).
+- Produces: a `Noise` node whose parameters live in `meta_group().current()` with full UI metadata; compute reads them via `value<T>`.
+
+- [ ] **Step 1: Read the metadata-key names to use exact strings**
+
+Run:
+```bash
+sed -n '1,80p' external/Meta/Meta/include/meta/metadata/keys.hpp
+```
+Note the exact constants for `widget_type`, `category`, `min`, `max`, `enum_items` (namespaces `meta::keys::ui::*` and `meta::keys::constraints::*`). Use these constants, not raw strings, in the code below.
+
+- [ ] **Step 2: Rewrite `setup_noise_node` against Meta**
+
+Replace the `--- Attributes` and `--- Attribute(s) order` sections (noise.cpp:49-70) with Meta authoring. Ports stay unchanged. Use the noise_type label→int list from `enum_mappings.noise_type_map` to build `enum_items` (a `std::vector<std::pair<int,std::string>>`). Example shape (adjust key constants per Step 1):
+
+```cpp
+  auto &c = node.meta_group().current();
+
+  // noise_type: int-backed enum dropdown
+  {
+    auto *a = c.add<int>(A_NOISE_TYPE, /*default*/ 0);
+    a->metadata().try_add(meta::keys::ui::label, std::string("Type"));
+    a->metadata().try_add(meta::keys::ui::widget_type, std::string("EnumComboBox"));
+    a->metadata().try_add(meta::keys::ui::category, std::string("Main Parameters"));
+    std::vector<std::pair<int, std::string>> items;
+    for (auto &[name, val] : enum_mappings.noise_type_map) items.emplace_back(val, name);
+    a->metadata().try_add(meta::keys::constraints::enum_items, items);
+  }
+
+  // kw: 2D wavenumber with X/Y lock
+  {
+    auto *a = c.add<glm::vec2>(A_KW, glm::vec2(2.f, 2.f));
+    a->metadata().try_add(meta::keys::ui::label, std::string("Spatial Frequency"));
+    a->metadata().try_add(meta::keys::ui::widget_type, std::string("LinkedSliders"));
+    a->metadata().try_add(std::string("ui.locked_xy"), true);
+    a->metadata().try_add(meta::keys::constraints::min, 0.f);
+    a->metadata().try_add(meta::keys::constraints::max, 64.f);
+    a->metadata().try_add(meta::keys::ui::category, std::string("Main Parameters"));
+  }
+
+  // seed
+  {
+    auto *a = c.add<int>(A_SEED, 1);
+    a->metadata().try_add(meta::keys::ui::label, std::string("Seed"));
+    a->metadata().try_add(meta::keys::constraints::min, 0);
+    a->metadata().try_add(meta::keys::ui::category, std::string("Main Parameters"));
+  }
+
+  // periodic
+  {
+    auto *a = c.add<bool>(A_PERIODIC, false);
+    a->metadata().try_add(meta::keys::ui::label, std::string("Periodic (tileable)"));
+    a->metadata().try_add(meta::keys::ui::widget_type, std::string("Checkbox"));
+    a->metadata().try_add(meta::keys::ui::category, std::string("Tiling"));
+  }
+```
+
+Note: `set_attr_ordered_key(...)` is dropped — order is insertion order, grouping is `ui.category`. Keep the `setup_post_process_heightmap_attributes(...)` call for now; the post-process attributes still use the legacy `attr` map (they render in a separate legacy panel section, acceptable for the PoC — call this out in the Task B3 GUI check).
+
+- [ ] **Step 3: Update `compute_noise_node` to read from Meta**
+
+Replace the param reads (noise.cpp:96-101) with:
+
+```cpp
+  auto &c = node.meta_group().current();
+  const auto noise_type = hmap::NoiseType(c.value<int>(A_NOISE_TYPE));
+  const glm::vec2 kw    = c.value<glm::vec2>(A_KW);
+  const auto seed       = static_cast<uint>(c.value<int>(A_SEED));
+  const auto periodic   = c.value<bool>(A_PERIODIC);
+```
+
+The compute body below (noise.cpp:103-145) is unchanged.
+
+- [ ] **Step 4: Build**
+
+Run:
+```bash
+cmake --build build -j --target hesiod 2>&1 | tail -20
+```
+Expected: builds clean. Fix type mismatches against the real key-constant names from Step 1 if the compiler complains.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Hesiod/src/model/nodes/nodes_function/noise.cpp
+git commit -m "feat(meta): author Noise node parameters on meta::ContainerGroup"
+```
+
+### Task B3: Render the Noise panel via `meta_qt`
+
+**Files:**
+- Modify: `Hesiod/src/gui/widgets/node_attributes_widget.cpp` (the `setup_layout()` path that builds `attr::AttributesWidget`, line 208)
+- Read (for exact API): `external/Meta/MetaUI/qt/include/meta_qt/container_group_widget.hpp`
+
+**Interfaces:**
+- Consumes: `BaseNode::uses_meta()`, `BaseNode::meta_group()` (Task B1); `meta_qt::ContainerGroupWidget(meta::ContainerGroup&, …, QWidget* parent)` or the free `meta_qt::render(meta::ContainerGroup&, …, QWidget*)` returning a `MetaWidget*` with a `value_changed`-style signal.
+- Produces: for a meta-backed node the settings panel is built by `meta_qt`; attribute edits trigger `GraphNode::update(node_id)` (recompute), same as the legacy path.
+
+- [ ] **Step 1: Read the exact widget constructor + change signal**
+
+Run:
+```bash
+sed -n '1,70p' external/Meta/MetaUI/qt/include/meta_qt/container_group_widget.hpp
+```
+Note the exact constructor parameters (the 2nd param between `group` and `parent`) and the signal(s) emitted on edit. Use these exact names below.
+
+- [ ] **Step 2: Branch the panel builder on `uses_meta()`**
+
+In `node_attributes_widget.cpp::setup_layout()`, before the `new attr::AttributesWidget(...)` construction (line 208), add:
+
+```cpp
+  if (p_node->uses_meta())
+  {
+    auto *meta_widget = new meta_qt::ContainerGroupWidget(p_node->meta_group(),
+                                                          /*2nd param per Step 1*/,
+                                                          this);
+    // wire edit -> recompute (signal name per Step 1)
+    connect(meta_widget, &meta_qt::ContainerGroupWidget:://*value_changed*/,
+            this,
+            [this]()
+            {
+              if (auto gno = this->p_graph_node.lock())
+                gno->update(this->node_id);
+            });
+    this->layout->addWidget(meta_widget);
+    return; // skip the legacy AttributesWidget path for meta nodes
+  }
+```
+
+(Match the existing recompute lambda already used at `node_attributes_widget.cpp:168-177`; reuse the same weak-ptr guard and `update` call.)
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+cmake --build build -j --target hesiod 2>&1 | tail -20
+```
+Expected: builds clean.
+
+- [ ] **Step 4: User GUI check — panel renders and recomputes**
+
+Hand to the user: launch the GUI, add a `Noise` node, select it. Confirm:
+1. The settings panel shows Type (dropdown), Spatial Frequency (linked X/Y sliders with the lock active), Seed, Periodic — grouped under "Main Parameters" / "Tiling" sections (`ui.category`).
+2. Editing Spatial Frequency with the lock on moves both components together.
+3. Editing any value re-renders the terrain preview (recompute fires).
+4. (Known PoC seam) the post-process attributes may appear in a separate legacy section — acceptable for now.
+
+Expected: 1-3 hold. Capture any discrepancy as a follow-up note.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Hesiod/src/gui/widgets/node_attributes_widget.cpp
+git commit -m "feat(meta): render meta-backed node panels via meta_qt"
+```
+
+### Task B4: Serialization — prototype both shapes and decide (TDD)
+
+**Files:**
+- Modify: `Hesiod/src/model/nodes/base_node.cpp` (`json_to` line 407, `json_from` line 381 — branch on `uses_meta()`)
+- Create: `Hesiod/data/examples/_poc_noise.hsd` (a saved graph with one Noise node, produced in Step 3)
+
+**Interfaces:**
+- Consumes: `meta::AttributeContainer::json_to()/json_from()`; the existing tolerant loader path.
+- Produces: a decision (recorded in the plan's companion spec) between (a) **adapter** — `json_to/from` translate the meta container to/from the existing flat `.hsd` attribute shape, and (b) **native** — emit `meta`'s container JSON under a versioned key. Both prototypes must **fail loud** on shape mismatch (no silent all-defaults).
+
+- [ ] **Step 1: Write the failing headless round-trip test**
+
+Use the CLI batch mode to save+reload. Create a throwaway script `scratch/poc_roundtrip.sh` (not committed):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+BIN=./build/Hesiod/hesiod   # adjust to actual binary path
+# 1. Save a graph containing a single Noise node with non-default params
+$BIN --load Hesiod/data/examples/_poc_noise.hsd --save /tmp/_poc_out.hsd --headless
+# 2. Compare the Noise node's serialized params before/after
+python3 - <<'PY'
+import json
+a = json.load(open("Hesiod/data/examples/_poc_noise.hsd"))
+b = json.load(open("/tmp/_poc_out.hsd"))
+# locate the Noise node in both and assert its attribute values match
+# (fields: noise_type, kw, seed, periodic)
+print("ROUNDTRIP_OK" if a == b else "ROUNDTRIP_MISMATCH")
+PY
+```
+
+- [ ] **Step 2: Run it to confirm it fails (no meta serialization yet)**
+
+Run:
+```bash
+bash scratch/poc_roundtrip.sh
+```
+Expected: FAIL — either the save errors (meta container not serialized) or `ROUNDTRIP_MISMATCH` (Noise params lost/defaulted on reload).
+
+- [ ] **Step 3: Create the fixture graph**
+
+Have the user build a graph with one `Noise` node, set non-default params (e.g. Type=perlin, kw=(4,4), seed=42, periodic=true), and save as `Hesiod/data/examples/_poc_noise.hsd`. (Or produce it headlessly once save works.)
+
+- [ ] **Step 4: Implement prototype (a) — adapter (keep flat `.hsd` shape)**
+
+In `base_node.cpp::json_to()`, branch: if `uses_meta()`, iterate `meta_group().current()` and emit each attribute in the existing flat shape (`{label, type, value, vmin, vmax}`) so the file is byte-compatible with today's format. In `json_from()`, when `uses_meta()`, read the flat keys and `set` them into the container via `value<T>(key) = ...` (or `set_from_any`). **Guard:** if a container key is absent from the JSON, log an error and count it; if any are missing, emit a single loud warning `[meta serialize] N attrs defaulted for node <id>` (do not silently default).
+
+```cpp
+// json_to (uses_meta branch): emit flat shape
+for (const auto &name : node.meta_group().current().insertion_order())
+{
+  const auto *attr = node.meta_group().current().find(name);
+  json[name] = { {"label", /*ui.label from metadata*/}, {"value", attr->to_any_json_value()} };
+  // include vmin/vmax when present in metadata
+}
+```
+
+- [ ] **Step 5: Run the round-trip; expect PASS for adapter**
+
+Run:
+```bash
+bash scratch/poc_roundtrip.sh
+```
+Expected: `ROUNDTRIP_OK`. If mismatch, fix the field mapping until identical.
+
+- [ ] **Step 6: Implement prototype (b) — native meta shape under a versioned key**
+
+Add a second code path (behind a local `constexpr bool kUseNativeMetaJson`) that instead writes `json["_meta"] = meta_group().json_to()` and, on load, detects `_meta` and calls `meta_group().json_from(...)`. Bump the node JSON with a `"meta_schema": 1` marker. **Guard:** if `uses_meta()` but neither the flat keys nor `_meta` are present, throw/log loudly rather than defaulting.
+
+- [ ] **Step 7: Measure and record the decision**
+
+Compare the two prototypes on: diff vs the current `.hsd` (does the Python `hsd` toolkit + `site/examples/*.hsd` still parse?), code complexity, and how the silent-default guard behaves. Record the chosen approach + rationale in `docs/superpowers/specs/2026-07-09-meta-migration-design.md` §6 (replace the "open" note with the decision). Keep the losing prototype's code out of the final commit.
+
+- [ ] **Step 8: Commit the chosen serialization + fixture**
+
+```bash
+git add Hesiod/src/model/nodes/base_node.cpp Hesiod/data/examples/_poc_noise.hsd
+git commit -m "feat(meta): serialize meta-backed Noise node (<chosen> shape) with fail-loud guard"
+```
+
+### Task B5: Facade-vs-codemod decision for the remaining 303 nodes
+
+**Files:**
+- Create/Modify: `docs/superpowers/specs/2026-07-09-meta-migration-design.md` §8 + §10 item 3 (record the decision)
+
+**Interfaces:**
+- Consumes: the ergonomics observed authoring `noise.cpp` against Meta directly (Task B2).
+- Produces: a decision — (a) **facade**: keep `BaseNode::add_attr<T>`/`get_attr<T>` signatures, back them with `meta` + a metadata-mapping shim, so the 303 node files change minimally; vs (b) **codemod**: rewrite each node's setup against the Meta API directly. No bulk code in this plan.
+
+- [ ] **Step 1: Sketch the facade shim signature**
+
+Based on Task B2, write (in the spec, not code) how a facade `add_attr<FloatAttribute>(key, label, def, min, max, fmt, log)` would translate to `container.add<float>(key, def)` + metadata `try_add`s. Note which of the 15 attribute types translate mechanically and which need bespoke handling (per the coverage matrix).
+
+- [ ] **Step 2: Estimate effort per approach**
+
+Record: facade = 1 shim + ~0 changes per node file (but a translation layer to maintain); codemod = ~304 file rewrites (mechanical for the ~96% clean types). Recommend one, with the reasoning tied to what B2 actually felt like.
+
+- [ ] **Step 3: Commit the decision**
+
+```bash
+git add docs/superpowers/specs/2026-07-09-meta-migration-design.md
+```
+(Note: `docs/superpowers` is gitignored in this repo — if the commit is desired, force-add or relocate per the user's preference; otherwise keep the spec update local.)
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Phase A (foundations) + Phase B (vertical PoC, serialization decision, facade decision) cover the design doc's Phase A + B. Phases C–E and node-merging are explicitly out of scope for this plan (separate plans).
+- **Serialization:** Task B4 prototypes BOTH shapes with a fail-loud guard against the silent-all-defaults failure mode identified in the spec §6 — the plan's highest-risk item, made headlessly testable via the CLI round-trip.
+- **Gap resolutions folded in:** `ui.locked_xy` (B2), `ui.category` grouping (B2), no seed widget (B2), `SnapshotManager` reset noted for later (not needed by Noise). `ui.data_provider`/`ui.tooltip` correctly deferred (Noise doesn't exercise Range/Cloud/tooltip-critical paths).
+- **External-API honesty:** where Meta's exact call signatures aren't fully known (panel widget ctor 2nd param, edit signal name, metadata key constants), the plan directs reading the specific header first (B2 Step 1, B3 Step 1) rather than inventing calls.
+
+---
+
+## Branch Strategy
+
+Phase A/B touches **one repo**: `otto-link/Hesiod`. All work is on the single branch `feature/meta-migration` (already checked out, off `upstream/dev`), fully isolated — it never merges to Hesiod `dev`/`main` until a deliberate cutover. Push target for the branch: `otto-link/Hesiod` (the `barrulus` fork is retiring; Hesiod's local `upstream` remote = otto-link — confirm before first push).
+
+**Meta is consumed, not modified, in this plan.** The `external/Meta` submodule is pinned to a frozen commit SHA — immutable, so it cannot drift regardless of what happens on Meta's `main`. No Meta branch, no `.gitmodules` branch tracking, no cross-repo submodule dance is needed for A/B.
+
+**When Meta first needs editing (a later phase — `ui.data_provider`, `ui.tooltip`):** create `feature/meta-migration` inside `external/Meta` off the then-pinned commit, commit Meta changes there, push to `otto-link/Meta`, and bump Hesiod's pin. That coordination is deferred to the phase that actually needs it, not front-loaded here.
+
+Other submodules (`Attributes`, `HighMap`, `GNode`, `GNodeGUI`, `QTerrainRenderer`, `QTextureDownloader`) are untouched and stay at their current pins. (`Attributes` removal is a later phase.)
+
+**Cutover (out of scope for this plan):** when the migration is proven and complete, Hesiod's `feature/meta-migration` branch merges to its `dev`. If Meta has by then diverged onto its own branch, merge Meta to its `dev` first, then bump Hesiod's pin, then merge Hesiod.
+
+> Branch name settled: `feature/meta-migration` (Hesiod is on it). Any Meta branch created in a later phase uses the same name for consistency.

--- a/docs/meta-migration/2026-07-10-data-provider-tooltip-design.md
+++ b/docs/meta-migration/2026-07-10-data-provider-tooltip-design.md
@@ -1,0 +1,195 @@
+# Meta capability: `ui.data_provider` (RangeBar histogram) + `ui.tooltip` — Design
+
+**Date:** 2026-07-10
+**Repo:** `otto-link/Meta` (+ minimal `otto-link/Hesiod` consumer for verification)
+**Status:** Design approved; ready for implementation plan.
+**Context:** First slice of the Meta-editing phase after the Phase A+B PoC
+(`docs/meta-migration/2026-07-09-*`). Closes gap **G1** (range slider with live input
+histogram) from the gaps doc / `otto-link/Meta#15`; lays the mechanism that also closes
+**G2** (cloud/points background image) in a fast follow. Adds **G6** (`ui.tooltip`).
+
+## 1. Goal
+
+Give Meta a general, Qt-free mechanism for a host to feed **runtime-computed data** into a
+widget that cannot produce it itself — a `ui.data_provider` metadata callback — and use it to
+render a **histogram behind the `RangeBar`** handles (Hesiod's signature range-editing UX).
+Add a `ui.tooltip` metadata key applied centrally. Verify end-to-end via one Hesiod node.
+
+**In scope:** the `data_provider` mechanism + the **RangeBar histogram** consumer; the
+`ui.tooltip` key; a targeted serialization skip for the non-serializable provider; one
+Hesiod-side consumer node for verification.
+
+**Explicitly out of scope (deferred):** the `PointsCanvas` background-image consumer (G2 —
+fast follow, same mechanism); the broad `_meta` values-only serialization trim; the widget
+sizing fix; migrating the fleet of Range-using nodes.
+
+## 2. Decisions (locked in brainstorming)
+
+- **Storage = metadata attribute (Approach A).** The callable lives in the attribute's
+  metadata container under the `ui.data_provider` key, matching Otto's #15 framing ("an
+  attribute that cannot be serialized"). Reuses the existing `meta::common::try_get` plumbing.
+- **Return type = one neutral struct** (`meta::ProviderData`), Qt-free; each backend converts.
+  One general `ui.data_provider`, not typed per-widget.
+- **Refresh = compose with existing panel rebuild.** No new refresh signal; Hesiod rebuilds
+  the settings panel on `update_finished`, which re-invokes the renderer → re-calls the provider.
+- **Consumer scope = RangeBar histogram first**, PointsCanvas image as a later fast follow.
+- **Tooltip = HTML**, applied centrally (per Otto #15).
+
+## 3. Branch & cross-repo setup
+
+This is the first work that edits Meta, so the deferred Meta branch is created now:
+- Inside `external/Meta`, create `feature/meta-migration` off the current frozen pin
+  (`e71e798`), commit all Meta changes there, push to `otto-link/Meta`.
+- Bump Hesiod's `external/Meta` submodule pin to the new Meta commit; commit the pin on
+  Hesiod's `feature/meta-migration` branch. Meta `main`/`dev` are never touched.
+- Standing rules hold: no PR/merge to any `dev`/`main` without explicit request; no CI.
+
+## 4. Meta core (`meta` library)
+
+### 4.1 `meta/core/data_provider.hpp` (new)
+
+```cpp
+#pragma once
+#include <functional>
+#include <vector>
+#include <cstdint>
+
+namespace meta
+{
+/// Qt-free payload a host supplies to a widget for runtime-computed display data.
+/// A provider populates the series fields (e.g. a histogram) and/or the image fields
+/// (e.g. a heightmap thumbnail); each UI backend converts to its native types.
+struct ProviderData
+{
+  std::vector<float> series_x;          ///< e.g. histogram bin centers
+  std::vector<float> series_y;          ///< e.g. histogram counts/heights
+
+  int                  image_width    = 0;
+  int                  image_height   = 0;
+  int                  image_channels = 0;   ///< 1, 3, or 4
+  std::vector<uint8_t> image_pixels;         ///< row-major, channel-interleaved
+
+  bool has_series() const { return !series_y.empty(); }
+  bool has_image() const
+  {
+    return image_width > 0 && image_height > 0 && !image_pixels.empty();
+  }
+};
+
+/// A host-supplied callback returning fresh display data on each call.
+using DataProvider = std::function<ProviderData()>;
+} // namespace meta
+```
+
+### 4.2 Type registration (so `Attribute<DataProvider>` compiles, serializes to null)
+
+`DataProvider` is non-serializable. Provide no-op specializations:
+- `TypeName<meta::DataProvider>::name = "data_provider"`.
+- `AttributeTraits<meta::DataProvider>`: `to_string` → `"<data_provider>"`; `json_to` →
+  `nullptr` (JSON null); `json_from` → no-op (leave the value untouched).
+
+These let `metadata().try_add(keys::ui::data_provider, DataProvider{...})` create an
+`Attribute<DataProvider>` through the existing plumbing without a compile error.
+
+### 4.3 Metadata keys (`meta/metadata/keys.hpp`)
+
+Add to `namespace meta::keys::ui`:
+```cpp
+inline constexpr char data_provider[] = "ui.data_provider";
+inline constexpr char tooltip[]       = "ui.tooltip";
+```
+
+### 4.4 Serialization skip (targeted)
+
+The provider lives in the serializable metadata container, so `serialize_metadata` /
+`AttributeContainer::json_to` must **omit** the `DataProvider` entry (its `json_to` yields
+null and the factory cannot reconstruct it on load). Skip metadata attributes whose stored
+type is `meta::DataProvider` (or, equivalently, whose serialized value is JSON null from the
+no-op trait). This is a *targeted* skip for the provider type only — the broad values-only
+`_meta` trim remains a separate deferred task. `json_from` correspondingly does not attempt to
+create it; the host re-sets the provider in node setup on every construction.
+
+## 5. MetaUI Qt (`meta_qt` library)
+
+### 5.1 `RangeBar` — histogram behind the handles
+
+- Add `void set_histogram(const std::vector<float> &x, const std::vector<float> &y);`
+  storing the series (empty clears it).
+- In `paintEvent`, before drawing the handles, draw the series as bars/an area normalized to
+  the widget rect (y scaled to max). No-op when the series is empty (identical to today's look).
+
+### 5.2 `glm_vec2.inl` — wire the provider in the `RangeBar` branch
+
+In the `widget_type == "RangeBar"` branch, after constructing the `RangeBar`:
+```cpp
+if (auto *mp = attr.metadata().find(meta::keys::ui::data_provider))
+{
+  if (auto *dp = mp->try_cast<meta::Attribute<meta::DataProvider>>())
+  {
+    const meta::DataProvider &provider = dp->value();
+    if (provider)
+    {
+      meta::ProviderData d = provider();
+      if (d.has_series())
+        bar->set_histogram(d.series_x, d.series_y);
+    }
+  }
+}
+```
+(Exact accessor confirmed against `attribute_container.hpp`/`abstract_attribute.hpp` at
+implementation time; `try_get` is for value types, so a `find` + `try_cast` is used for the
+function-typed metadata entry.)
+
+### 5.3 `ui.tooltip` — central application
+
+Where `container_widget` builds each attribute's row (label + widget), read
+`ui.tooltip` from the attribute metadata (a `std::string`, HTML allowed) and
+`setToolTip(QString::fromStdString(...))` on the row/label widget. No per-renderer wiring.
+
+## 6. Hesiod-side verification (minimal consumer)
+
+Wire the provider into **one** Hesiod node that has a Range attribute, authored on Meta:
+`a->metadata().try_add(meta::keys::ui::data_provider, meta::DataProvider{[&node, port_id]{ …read input VirtualArray, bin a 256-bin histogram, return ProviderData with series_x/series_y… }})`
+— the direct analogue of today's `setup_histogram_for_range_slider.cpp`. This is a *verification*
+use, not a Range-node migration sweep. GUI check: the histogram renders behind the range
+handles and refreshes when the upstream node recomputes.
+
+## 7. Testing
+
+**Meta core (`Meta/tests`):**
+- `ProviderData::has_series`/`has_image` predicates.
+- `Attribute<DataProvider>` round-trips through serialization as null: `json_to` on a
+  container holding a provider omits the entry; `json_from` leaves node behaviour intact; the
+  host-set provider remains callable in-memory.
+- `keys::ui::data_provider` / `keys::ui::tooltip` present and correctly valued.
+
+**MetaUI:**
+- `RangeBar::set_histogram` with a series then `paintEvent` runs without error; empty series
+  restores the plain look.
+- `glm_vec2` RangeBar renderer with a metadata provider feeds the bar; with none, unchanged.
+
+**Hesiod end-to-end (controller/user, per repo precedent):**
+- Build via the nix devshell (capped `-j4`, detached).
+- GUI (user): histogram appears behind the range handles on the verification node and
+  updates on recompute; `ui.tooltip` shows on hover; no crash.
+
+## 8. Error handling / edge cases
+
+- Provider absent → widgets render exactly as today (no series, no tooltip).
+- Provider present but returns empty `ProviderData` → treated as "no data", plain look.
+- Provider throws → caught at the renderer call site, logged, plain look (a bad host callback
+  must not crash the panel).
+- Loading a `.hsd` whose author stored a provider (shouldn't happen — skipped on save) → the
+  skip on `json_to` guarantees no provider key on disk; `json_from` never reconstructs one.
+
+## 9. Components summary (isolation)
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `meta::ProviderData` / `DataProvider` | Qt-free data contract | std only |
+| `AttributeTraits/TypeName<DataProvider>` | make it a non-serializable metadata attribute | attribute traits |
+| serialize-skip | keep provider out of `.hsd` | metadata serialization |
+| `RangeBar::set_histogram` + paint | draw series behind handles | Qt |
+| `glm_vec2.inl` RangeBar wiring | read provider → feed RangeBar | RangeBar, metadata |
+| `ui.tooltip` in `container_widget` | central tooltip application | Qt, keys |
+| Hesiod verification node | prove it end-to-end | all of the above |

--- a/docs/meta-migration/2026-07-10-data-provider-tooltip-plan.md
+++ b/docs/meta-migration/2026-07-10-data-provider-tooltip-plan.md
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- Meta edits are committed on `external/Meta`'s `feature/meta-migration` branch (created off the frozen pin `e71e798`), pushed to `otto-link/Meta`. Meta `main`/`dev` are never touched. Hesiod edits stay on Hesiod's `feature/meta-migration`. No PR/merge to any `dev`/`main` without explicit request. No CI.
+- Meta edits are committed on `external/Meta`'s `feature/meta-migration` branch (created off the frozen pin `e71e798`) and kept **local/unpushed** for now (do NOT push to `otto-link/Meta` yet). Meta `main`/`dev` are never touched. Hesiod edits stay on Hesiod's `feature/meta-migration`. No PR/merge to any `dev`/`main` without explicit request. No CI.
 - Storage = non-serializable metadata attribute under key `ui.data_provider` (Approach A). Return type = the neutral `meta::ProviderData` struct; one general `DataProvider = std::function<ProviderData()>`.
 - The `DataProvider` metadata entry MUST be omitted from serialization (`json_to`), and `json_from` must never try to reconstruct it. Targeted skip for the `DataProvider` type only — NOT the broad `_meta` values-only trim (deferred).
 - Tooltips are HTML, applied centrally (one place), not per-renderer.
@@ -39,7 +39,7 @@
 ```bash
 cd /home/barrulus/dev/Hesiod/external/Meta
 git switch -c feature/meta-migration   # created off current HEAD = pinned e71e798
-git push -u origin feature/meta-migration
+# NOTE: keep this branch LOCAL — do NOT push to otto-link/Meta yet (per user).
 git branch --show-current              # expect: feature/meta-migration
 ```
 

--- a/docs/meta-migration/2026-07-10-data-provider-tooltip-plan.md
+++ b/docs/meta-migration/2026-07-10-data-provider-tooltip-plan.md
@@ -1,0 +1,475 @@
+# `ui.data_provider` (RangeBar histogram) + `ui.tooltip` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a general Qt-free `ui.data_provider` host-callback mechanism to Meta and use it to render a live histogram behind the `RangeBar` (gap G1), plus a `ui.tooltip` key (G6), verified end-to-end via one Hesiod node.
+
+**Architecture:** The callable is stored as a non-serializable metadata `Attribute<meta::DataProvider>` under `ui.data_provider`; it returns a neutral `meta::ProviderData`. Meta's `RangeBar` gains a `set_histogram` + paint; the `glm::vec2` RangeBar renderer reads the provider and feeds it. `ui.tooltip` is applied centrally in the container-row builder. All Meta edits land on a dedicated Meta branch, pinned into Hesiod.
+
+**Tech Stack:** C++20, CMake ≥3.22, Qt6, nlohmann_json. Libraries: `meta` (core), `meta_qt` (Qt UI). Design: `docs/meta-migration/2026-07-10-data-provider-tooltip-design.md`.
+
+## Global Constraints
+
+- Meta edits are committed on `external/Meta`'s `feature/meta-migration` branch (created off the frozen pin `e71e798`), pushed to `otto-link/Meta`. Meta `main`/`dev` are never touched. Hesiod edits stay on Hesiod's `feature/meta-migration`. No PR/merge to any `dev`/`main` without explicit request. No CI.
+- Storage = non-serializable metadata attribute under key `ui.data_provider` (Approach A). Return type = the neutral `meta::ProviderData` struct; one general `DataProvider = std::function<ProviderData()>`.
+- The `DataProvider` metadata entry MUST be omitted from serialization (`json_to`), and `json_from` must never try to reconstruct it. Targeted skip for the `DataProvider` type only — NOT the broad `_meta` values-only trim (deferred).
+- Tooltips are HTML, applied centrally (one place), not per-renderer.
+- Consumer scope: `RangeBar` histogram only. `PointsCanvas` background image is a separate fast-follow (out of scope here).
+- Build env (per repo precedent): build via `nix develop ~/quixote#cpp-qt-desktop`, cap `-j4`, run detached (unbounded `-j` OOMs). GUI verification is user-driven. Qt is 6.11.1; if `build/` goes stale, `rm -rf build` + fresh configure.
+- Staging discipline: each commit stages ONLY its named files; the dirty `external/{GNode,GNodeGUI,HighMap}` submodules and untracked files must never be staged. Never `git add -A`/`.`.
+
+---
+
+## Task 1: Meta branch + core data contract (`ProviderData`, `DataProvider`, traits, keys)
+
+**Files:**
+- `external/Meta` — create branch `feature/meta-migration` (git op)
+- Create: `external/Meta/Meta/include/meta/core/data_provider.hpp`
+- Modify: `external/Meta/Meta/include/meta/metadata/keys.hpp` (add two keys to `namespace meta::keys::ui`)
+- Modify: `external/Meta/tests/test_meta/main.cpp` (append assertions)
+
+**Interfaces produced:**
+- `struct meta::ProviderData { std::vector<float> series_x, series_y; int image_width, image_height, image_channels; std::vector<uint8_t> image_pixels; bool has_series() const; bool has_image() const; };`
+- `using meta::DataProvider = std::function<meta::ProviderData()>;`
+- `AttributeTraits<meta::DataProvider>` (no-op) + `TypeName<meta::DataProvider>` so `Attribute<meta::DataProvider>` compiles.
+- `meta::keys::ui::data_provider` = `"ui.data_provider"`, `meta::keys::ui::tooltip` = `"ui.tooltip"`.
+
+- [ ] **Step 1: Create the Meta feature branch off the frozen pin**
+
+```bash
+cd /home/barrulus/dev/Hesiod/external/Meta
+git switch -c feature/meta-migration   # created off current HEAD = pinned e71e798
+git push -u origin feature/meta-migration
+git branch --show-current              # expect: feature/meta-migration
+```
+
+- [ ] **Step 2: Create `data_provider.hpp` with the struct, alias, and no-op registration**
+
+Create `external/Meta/Meta/include/meta/core/data_provider.hpp`:
+
+```cpp
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "meta/type/attribute_traits.hpp"
+#include "meta/type/type_name.hpp"
+
+namespace meta
+{
+
+/// Qt-free payload a host supplies to a widget for runtime-computed display data.
+struct ProviderData
+{
+  std::vector<float>   series_x;             ///< e.g. histogram bin centers
+  std::vector<float>   series_y;             ///< e.g. histogram counts/heights
+  int                  image_width    = 0;
+  int                  image_height   = 0;
+  int                  image_channels = 0;   ///< 1, 3, or 4
+  std::vector<uint8_t> image_pixels;         ///< row-major, channel-interleaved
+
+  bool has_series() const { return !series_y.empty(); }
+  bool has_image() const
+  {
+    return image_width > 0 && image_height > 0 && !image_pixels.empty();
+  }
+};
+
+/// Host-supplied callback returning fresh display data on each call. Non-serializable.
+using DataProvider = std::function<ProviderData()>;
+
+/// No-op traits: a DataProvider carries runtime state that must not be serialized.
+template <> struct AttributeTraits<DataProvider>
+{
+  static std::string   to_string(const DataProvider &) { return "<data_provider>"; }
+  static nlohmann::json json_to(const DataProvider &) { return nullptr; }
+  static DataProvider   json_from(const nlohmann::json &) { return {}; }
+};
+
+} // namespace meta
+
+META_DEFINE_TYPE_NAME(meta::DataProvider);
+```
+
+(If `META_DEFINE_TYPE_NAME` with a qualified `meta::DataProvider` argument does not compile as
+written — the macro opens `namespace meta` — invoke it with `DataProvider` at the point the
+macro expects; confirm the exact form against `tests/test_meta/main.cpp:40`
+(`META_DEFINE_TYPE_NAME(Vec2);`) and `meta/type/type_name.hpp`.)
+
+- [ ] **Step 3: Add the two metadata keys**
+
+In `external/Meta/Meta/include/meta/metadata/keys.hpp`, inside `namespace meta::keys::ui`, add:
+```cpp
+inline constexpr char data_provider[] = "ui.data_provider";
+inline constexpr char tooltip[]       = "ui.tooltip";
+```
+
+- [ ] **Step 4: Write assertions in the Meta test main**
+
+In `external/Meta/tests/test_meta/main.cpp`, add `#include "meta/core/data_provider.hpp"` and, inside `main()`, append:
+```cpp
+{
+  // ProviderData predicates
+  meta::ProviderData d;
+  assert(!d.has_series() && !d.has_image());
+  d.series_y = {1.f, 2.f};
+  assert(d.has_series());
+
+  // Attribute<DataProvider> compiles, to_string is the no-op sentinel
+  meta::AttributeContainer c;
+  bool called = false;
+  c.add<meta::DataProvider>("p", meta::DataProvider{[&]{ called = true; return meta::ProviderData{}; }});
+  auto *a = c.find("p");
+  assert(a && a->to_string() == "<data_provider>");
+
+  // the stored provider is callable
+  auto *typed = a->try_cast<meta::Attribute<meta::DataProvider>>();
+  assert(typed && typed->value());
+  typed->value()();
+  assert(called);
+
+  std::cout << "[data_provider] core OK" << std::endl;
+}
+```
+(Confirm `AttributeContainer::add<T>`, `find`, and `AbstractAttribute::try_cast` signatures
+against `meta/core/attribute_container.hpp` / `abstract_attribute.hpp`; they matched the Hesiod
+PoC usage.)
+
+- [ ] **Step 5: Build & run the Meta test standalone (controller)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c '
+  cd /home/barrulus/dev/Hesiod/external/Meta
+  cmake -B build-test -DMETA_ENABLE_TESTS=ON -DMETA_ENABLE_QT_UI=OFF >/dev/null &&
+  cmake --build build-test -j4 --target test_meta 2>&1 | tail -15 &&
+  ./build-test/tests/test_meta/test_meta'
+```
+Expected: builds; prints `[data_provider] core OK`; exits 0. (Confirm the test binary path/target
+name from `tests/test_meta/CMakeLists.txt`.)
+
+- [ ] **Step 6: Commit (on the Meta branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod/external/Meta
+git add Meta/include/meta/core/data_provider.hpp Meta/include/meta/metadata/keys.hpp tests/test_meta/main.cpp
+git commit -m "feat: add ui.data_provider mechanism (ProviderData + non-serializable DataProvider) and ui.tooltip key"
+```
+
+---
+
+## Task 2: Meta serialization skip for `DataProvider`
+
+**Files:**
+- Modify: `external/Meta/Meta/src/attribute_container.cpp` (`AttributeContainer::json_to`, ~line 185)
+- Modify: `external/Meta/tests/test_meta/main.cpp` (append assertion)
+
+**Interfaces:**
+- Consumes: `meta::DataProvider` (Task 1).
+- Produces: `AttributeContainer::json_to()` omits any attribute whose stored type is `meta::DataProvider`; `json_from` (which only updates existing attrs / factory-creates by type name) never reconstructs one because it is absent from the JSON.
+
+- [ ] **Step 1: Add the failing assertion**
+
+In `external/Meta/tests/test_meta/main.cpp` `main()`, append:
+```cpp
+{
+  meta::AttributeContainer c;
+  c.add<int>("keep", 7);
+  c.add<meta::DataProvider>("skip", meta::DataProvider{[]{ return meta::ProviderData{}; }});
+  auto j = c.json_to();
+  assert(j.contains("keep"));
+  assert(!j.contains("skip"));   // DataProvider omitted from serialization
+  std::cout << "[data_provider] serialize-skip OK" << std::endl;
+}
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod/external/Meta && cmake --build build-test -j4 --target test_meta >/dev/null 2>&1 && ./build-test/tests/test_meta/test_meta'
+```
+Expected: FAIL — assertion `!j.contains("skip")` fires (the entry is currently serialized as null).
+
+- [ ] **Step 3: Skip `DataProvider`-typed entries in `json_to`**
+
+In `attribute_container.cpp`, the loop at ~line 190-192 is `for (...) j[name] = attr->json_to();`. Guard it:
+```cpp
+#include "meta/core/data_provider.hpp"   // add to includes
+// ...
+for (const auto &name : insertion_order_)
+{
+  const auto *attr = /* existing lookup */;
+  if (attr->type() == std::type_index(typeid(meta::DataProvider)))
+    continue;                             // non-serializable runtime provider
+  j[name] = attr->json_to();
+}
+```
+(Match the exact existing loop form/variable names in the file. `AbstractAttribute::type()`
+returns `std::type_index` — verified in `abstract_attribute.hpp`.)
+
+- [ ] **Step 4: Run to confirm it passes**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod/external/Meta && cmake --build build-test -j4 --target test_meta >/dev/null 2>&1 && ./build-test/tests/test_meta/test_meta'
+```
+Expected: PASS — both `[data_provider] core OK` and `[data_provider] serialize-skip OK`; exit 0.
+
+- [ ] **Step 5: Commit (Meta branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod/external/Meta
+git add Meta/src/attribute_container.cpp tests/test_meta/main.cpp
+git commit -m "feat: omit non-serializable DataProvider metadata entries from json_to"
+```
+
+---
+
+## Task 3: `RangeBar` histogram (`set_histogram` + paint)
+
+**Files:**
+- Modify: `external/Meta/MetaUI/qt/include/meta_qt/widgets/range_bar.hpp`
+- Modify: `external/Meta/MetaUI/qt/src/widgets/range_bar.cpp` (`paintEvent`)
+
+**Interfaces:**
+- Produces: `void RangeBar::set_histogram(const std::vector<float> &x, const std::vector<float> &y);` — stores the series (empty clears); `paintEvent` draws it behind the handles.
+
+- [ ] **Step 1: Declare the setter + members in the header**
+
+In `range_bar.hpp`: in `public:` add
+```cpp
+  void set_histogram(const std::vector<float> &x, const std::vector<float> &y);
+```
+in `private:` (near the other members, ~line 56) add
+```cpp
+  std::vector<float> hist_x_;
+  std::vector<float> hist_y_;
+```
+Ensure `#include <vector>` is present.
+
+- [ ] **Step 2: Implement the setter + histogram draw**
+
+In `range_bar.cpp`, add:
+```cpp
+void RangeBar::set_histogram(const std::vector<float> &x, const std::vector<float> &y)
+{
+  this->hist_x_ = x;
+  this->hist_y_ = y;
+  this->update();
+}
+```
+In `paintEvent`, at the very start of painting (before the existing track/handles drawing), add a bars pass that runs only when data is present:
+```cpp
+if (!this->hist_y_.empty())
+{
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing, false);
+  const QRect r = this->rect();
+  const float ymax = *std::max_element(this->hist_y_.begin(), this->hist_y_.end());
+  if (ymax > 0.f)
+  {
+    const int   n  = static_cast<int>(this->hist_y_.size());
+    const float bw = static_cast<float>(r.width()) / static_cast<float>(n);
+    QColor c = this->palette().color(QPalette::Mid);
+    c.setAlpha(90);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(c);
+    for (int i = 0; i < n; ++i)
+    {
+      const float h = (this->hist_y_[i] / ymax) * r.height();
+      painter.drawRect(QRectF(r.left() + i * bw, r.bottom() - h, bw, h));
+    }
+  }
+}
+```
+Add `#include <algorithm>` and ensure `<QPainter>`/`<QPalette>` are included (they are, since paintEvent already paints). The existing handle/track drawing follows and paints on top.
+
+- [ ] **Step 3: Build `meta_qt` (controller)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target meta_qt 2>&1 | tail -12'
+```
+Expected: `meta_qt` compiles + links (`libmeta_qt.a`). (This uses Hesiod's `build/` which has `META_ENABLE_QT_UI=ON`.)
+
+- [ ] **Step 4: Commit (Meta branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod/external/Meta
+git add MetaUI/qt/include/meta_qt/widgets/range_bar.hpp MetaUI/qt/src/widgets/range_bar.cpp
+git commit -m "feat(qt): RangeBar renders an optional histogram behind the handles"
+```
+
+---
+
+## Task 4: Wire the provider into the RangeBar renderer + apply `ui.tooltip`
+
+**Files:**
+- Modify: `external/Meta/MetaUI/qt/include/meta_qt/widget_renderer_inl/glm_vec2.inl` (RangeBar branch, ~line 225)
+- Modify: `external/Meta/MetaUI/qt/src/container_widget/container_widget.cpp` (per-attribute row builder)
+
+**Interfaces:**
+- Consumes: `RangeBar::set_histogram` (Task 3); `meta::keys::ui::data_provider`/`::tooltip`, `meta::DataProvider` (Task 1).
+- Produces: a RangeBar-rendered `glm::vec2` attribute with a `ui.data_provider` gets its histogram fed on build; any attribute with `ui.tooltip` gets a hover tooltip.
+
+- [ ] **Step 1: Feed the provider in the RangeBar branch**
+
+In `glm_vec2.inl`, inside the `widget_type == "RangeBar"` branch, after the `RangeBar *bar = new RangeBar(...)` construction, add:
+```cpp
+if (const auto *mp = attr.metadata().find(meta::keys::ui::data_provider))
+{
+  if (const auto *dp = mp->try_cast<meta::Attribute<meta::DataProvider>>())
+  {
+    const meta::DataProvider &provider = dp->value();
+    if (provider)
+    {
+      try
+      {
+        meta::ProviderData d = provider();
+        if (d.has_series())
+          bar->set_histogram(d.series_x, d.series_y);
+      }
+      catch (...)
+      {
+        // a faulty host provider must not crash the panel
+      }
+    }
+  }
+}
+```
+Add `#include "meta/core/data_provider.hpp"` to the `.inl`'s includes. (Confirm the local variable
+name for the RangeBar and the `attr` handle from the surrounding branch; use them verbatim.)
+
+- [ ] **Step 2: Apply `ui.tooltip` centrally in the row builder**
+
+In `container_widget.cpp`, locate where each attribute's row (label + editor widget) is created.
+After the row widget exists, add:
+```cpp
+if (const std::string tip = meta::common::try_get<std::string>(*attr, meta::keys::ui::tooltip, "");
+    !tip.empty())
+  row_widget->setToolTip(QString::fromStdString(tip));
+```
+(Use the actual row/label widget variable and the actual attribute handle from the surrounding
+code; `meta::common::try_get<std::string>` is the existing metadata accessor in
+`meta_common.hpp`. Ensure `<QString>` is available.)
+
+- [ ] **Step 3: Build `meta_qt` (controller)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target meta_qt 2>&1 | tail -12'
+```
+Expected: `meta_qt` compiles + links.
+
+- [ ] **Step 4: Commit (Meta branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod/external/Meta
+git add MetaUI/qt/include/meta_qt/widget_renderer_inl/glm_vec2.inl MetaUI/qt/src/container_widget/container_widget.cpp
+git commit -m "feat(qt): feed ui.data_provider histogram into RangeBar; apply ui.tooltip centrally"
+```
+
+---
+
+## Task 5: Bump Hesiod pin + Hesiod verification node + build/GUI
+
+**Files:**
+- Modify: `external/Meta` gitlink (submodule pin) — committed on Hesiod's branch
+- Modify: one Hesiod node file under `Hesiod/src/model/nodes/nodes_function/` (chosen in Step 1)
+
+**Interfaces:**
+- Consumes: everything above (the Meta branch tip).
+- Produces: a Hesiod node whose Range attribute is authored on Meta with a working `ui.data_provider` histogram lambda; the submodule pin advanced to the Meta branch tip.
+
+- [ ] **Step 1: Choose the verification node**
+
+Pick the SIMPLEST node that uses a `RangeAttribute` with a histogram, to fully migrate its
+attributes to Meta (like the Noise PoC). Run:
+```bash
+cd /home/barrulus/dev/Hesiod
+grep -rl "setup_histogram_for_range_attribute\|RangeAttribute" Hesiod/src/model/nodes/nodes_function/ | head
+```
+Prefer a node with few attributes (e.g. a remap/clamp-style node). Record the choice. All of its
+attributes must move to the meta container (the panel branches whole-node on `uses_meta()`).
+
+- [ ] **Step 2: Author the node's attributes on Meta, with the range `ui.data_provider`**
+
+Migrate the chosen node's `setup_*` to the meta container (same pattern as `noise.cpp`: `add<T>`
++ `ui.*`/`constraints.*` metadata). For its Range attribute (a `glm::vec2` with
+`widget_type = "RangeBar"`), attach the provider — the analogue of
+`setup_histogram_for_range_slider.cpp`:
+```cpp
+auto *range = c.add<glm::vec2>(A_REMAP, glm::vec2(0.f, 1.f));
+range->metadata().try_add(meta::keys::ui::widget_type, std::string("RangeBar"));
+range->metadata().try_add(meta::keys::constraints::min, 0.f);
+range->metadata().try_add(meta::keys::constraints::max, 1.f);
+range->metadata().try_add(meta::keys::ui::tooltip, std::string("<b>Remap range</b>"));
+range->metadata().try_add(
+    meta::keys::ui::data_provider,
+    meta::DataProvider{
+        [&node, port_id = std::string(P_IN)]() -> meta::ProviderData
+        {
+          meta::ProviderData d;
+          hmap::VirtualArray *p_in = node.get_value_ref<hmap::VirtualArray>(port_id);
+          if (!p_in) return d;
+          float vmin = p_in->min(node.cfg().cm_cpu);
+          float vmax = p_in->max(node.cfg().cm_cpu);
+          if (vmin == vmax) return d;
+          const int   nbins = 256;
+          hmap::Array a = p_in->to_array({256, 256}, node.cfg().cm_cpu);
+          d.series_x = hmap::linspace(vmin, vmax, nbins, false);
+          d.series_y.assign(nbins, 0.f);
+          const float sa = 1.f / (vmax - vmin) * (nbins - 1);
+          const float sb = -vmin / (vmax - vmin) * (nbins - 1);
+          for (int j = 0; j < a.shape.y; ++j)
+            for (int i = 0; i < a.shape.x; ++i)
+              d.series_y[static_cast<int>(sa * a(i, j) + sb)] += 1.f;
+          return d;
+        }});
+```
+Update the node's `compute_*` to read its params from the meta container (`c.value<T>(...)`),
+as in `noise.cpp`. Include `meta/core/data_provider.hpp` and `meta/metadata/keys.hpp`.
+
+- [ ] **Step 3: Bump the Hesiod submodule pin to the Meta branch tip**
+
+```bash
+cd /home/barrulus/dev/Hesiod
+git -C external/Meta rev-parse --short HEAD    # Meta branch tip (note it)
+git add external/Meta                          # stage the advanced gitlink
+```
+
+- [ ] **Step 4: Build Hesiod (controller, detached)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target hesiod 2>&1 | tail -20; echo EXIT=${PIPESTATUS[0]}'
+```
+Expected: `Linking CXX executable ... bin/hesiod`, `EXIT=0`. (Run in background per env notes.)
+
+- [ ] **Step 5: Commit (Hesiod branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod
+git add external/Meta Hesiod/src/model/nodes/nodes_function/<chosen_node>.cpp
+git commit -m "feat(meta): bump Meta pin; verify ui.data_provider histogram on <chosen_node> RangeBar"
+```
+
+- [ ] **Step 6: GUI verification (user-driven)**
+
+Launch `build/bin/hesiod`. Add the chosen node, connect a generator (e.g. Noise) to its input.
+Confirm:
+1. A **histogram renders behind the RangeBar handles** and reflects the input data.
+2. It **updates** when the upstream node recomputes (change the noise → histogram changes).
+3. The range attribute's **hover tooltip** shows the HTML text.
+4. No crash on panel open / range edit.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** §4 core (Task 1 data_provider.hpp/traits/keys; Task 2 serialize skip), §5 MetaUI (Task 3 RangeBar; Task 4 renderer wiring + tooltip), §3 branch/pin (Task 1 branch, Task 5 pin), §6 verification (Task 5), §7 testing (Meta unit asserts Tasks 1-2; build + GUI Tasks 3-5). PointsCanvas image and the broad `_meta` trim are correctly excluded (deferred).
+- **Serialization:** the skip is a targeted `typeid(DataProvider)` check in `json_to` (Task 2), matching the spec's "targeted skip, not the broad trim."
+- **Type consistency:** `set_histogram(x, y)` (Task 3) is fed exactly as declared from Task 4; `ProviderData.series_x/series_y` names consistent Task 1 → Task 5; `keys::ui::data_provider`/`tooltip` consistent throughout.
+- **External-API confirmations flagged:** the `META_DEFINE_TYPE_NAME` form (Task 1), the `json_to` loop variables (Task 2), the RangeBar/`attr` handles in `glm_vec2.inl` and the row-widget in `container_widget.cpp` (Task 4), and the test-binary path (Task 1) are each directed to the specific source to confirm, not invented.

--- a/docs/meta-migration/2026-07-11-data-provider-image-design.md
+++ b/docs/meta-migration/2026-07-11-data-provider-image-design.md
@@ -1,0 +1,123 @@
+# Meta capability: `ui.data_provider` image consumer (PointsCanvas background) — Design
+
+**Date:** 2026-07-11
+**Repo:** `otto-link/Meta` (+ minimal `otto-link/Hesiod` consumer for verification)
+**Status:** Design approved; ready for implementation plan.
+**Context:** Fast-follow to the G1 histogram work (`docs/meta-migration/2026-07-10-data-provider-*`).
+Closes gap **G2** (cloud/points editor with a heightmap background) by reusing the existing
+`ui.data_provider` mechanism for its *image* payload, proving "one hook serves both series and
+image".
+
+## 1. Goal
+
+Render a live heightmap thumbnail behind Meta's `PointsCanvas` point-cloud editor, fed by the
+same `ui.data_provider` callback built in G1 — using the `image_*` fields of `meta::ProviderData`
+that already exist. Verify end-to-end by migrating one Hesiod Cloud node.
+
+**In scope:** the `PointsCanvas` background-image consumer + the `std_vector_glm_vec3.inl`
+renderer wiring; one Hesiod verification node (`cloud.cpp`).
+
+**Explicitly NOT in scope (already done or deferred):** the `ui.data_provider` mechanism,
+`ProviderData` struct, non-serializable storage, and the `json_to` skip (all built in G1); the
+broad `_meta` values-only trim; the widget-width fix; refresh approach #1 (sync-not-rebuild).
+
+## 2. Why there is no Meta *core* change
+
+G1 already delivered, in `meta/core/data_provider.hpp`:
+- `ProviderData` with `image_width`, `image_height`, `image_channels`, `image_pixels` (row-major,
+  channel-interleaved) and `has_image()`.
+- `using DataProvider = std::function<ProviderData()>` stored under `meta::keys::ui::data_provider`
+  as a non-serializable metadata attribute, with the `AttributeContainer::json_to` skip.
+
+So G2 needs no new type, key, trait, or serialization change — only a new *consumer* widget and
+its renderer wiring, plus a Hesiod node to exercise it.
+
+## 3. Meta (`meta_qt`) — PointsCanvas background
+
+### 3.1 `PointsCanvas` (`widgets/points_canvas.{hpp,cpp}`)
+- Add `void set_background_image(const std::vector<uint8_t> &pixels, int w, int h, int channels);`
+  storing the pixels + dims (empty `pixels` clears it).
+- In `paintEvent`, draw the background FIRST (under the points): build a `QImage` from the stored
+  pixels (`QImage::Format_RGB888` for 3 channels, `Format_RGBA8888` for 4, `Format_Grayscale8`
+  for 1), scale it to the widget rect, and `drawImage`. The existing point/grid drawing follows
+  on top. No-op when no image is set (identical to today's look).
+
+### 3.2 `std_vector_glm_vec3.inl` (the `PointsEditor` branch)
+After the `PointsCanvas` is constructed, read the provider (mirroring the RangeBar wiring in
+`glm_vec2.inl`):
+```cpp
+if (const auto *mp = attr.metadata().find(meta::keys::ui::data_provider))
+  if (const auto *dp = mp->try_cast<meta::Attribute<meta::DataProvider>>())
+  {
+    const meta::DataProvider &provider = dp->value();
+    if (provider)
+      try
+      {
+        meta::ProviderData d = provider();
+        if (d.has_image())
+          canvas->set_background_image(d.image_pixels, d.image_width,
+                                       d.image_height, d.image_channels);
+      }
+      catch (...) { /* a faulty host provider must not crash the panel */ }
+  }
+```
+Add `#include "meta/core/data_provider.hpp"`. (Confirm the local canvas variable name and the
+`attr` handle from the surrounding `PointsEditor` branch at implementation time.)
+
+## 4. Orientation & scaling
+
+The legacy `setup_background_image_for_cloud_attribute.cpp` vertically mirrors the thumbnail
+(`QImage(...).mirrored(false, true)`) so the image origin matches the point-canvas coordinate
+system (points use a bottom-left-ish origin; QImage is top-left). To keep the thumbnail aligned
+with point positions, the **Hesiod provider returns pixels already oriented to the canvas** (i.e.
+it applies the same vertical flip the legacy helper did), and the renderer draws them as-is
+scaled to the rect. Keeping the flip host-side (not in `PointsCanvas`) preserves Meta's
+neutrality — the canvas just blits whatever pixels it's given.
+
+## 5. Hesiod verification node — `cloud.cpp`
+
+`cloud.cpp` is the simplest fit: ports IN `background` (`hmap::VirtualArray`), OUT `cloud`
+(`hmap::Cloud`); one `CloudAttribute` `A_CLOUD`; and it already calls
+`setup_background_image_for_cloud_attribute(node, A_CLOUD, P_BACKGROUND)`.
+
+Migrate it fully onto Meta (same pattern as `saturate.cpp`):
+- `A_CLOUD` → `c.add<std::vector<glm::vec3>>("cloud", {})` (this vector type is registered in
+  Meta) + metadata `ui::label`="Cloud", `ui::widget_type`="PointsEditor", `ui::category`="Main".
+- Attach a `ui::data_provider` lambda returning `ProviderData` with `image_*` = the colorized
+  `background` input (256×256, `hmap::Cmap::MAGMA`, RGB via `to_img_8bit()`), vertically flipped
+  to match the canvas — the direct analogue of `setup_background_image_for_cloud_attribute`.
+- `compute_cloud_node` reads `c.value<std::vector<glm::vec3>>("cloud")` and builds the
+  `hmap::Cloud` output as before.
+- Keep `#include "attributes.hpp"`/`using namespace attr;` only if still needed; add
+  `meta/core/data_provider.hpp` and `meta/metadata/keys.hpp`.
+
+## 6. Data flow, refresh, error handling
+
+Identical to G1: the provider is called at render; the background refreshes on panel rebuild
+(recompute); point edits commit on `edit_ended` (the refresh fix already merged). A faulty
+provider is caught at the renderer and yields a plain (no-background) canvas. Absent provider →
+unchanged behavior.
+
+## 7. Testing
+
+- **Meta core:** unchanged — no new core code (the G1 `ProviderData`/skip tests still cover it).
+  Optionally extend the `has_image()` assertion (already present) — no new test required.
+- **MetaUI:** build `meta_qt` (the `PointsCanvas` change + renderer wiring compile). The canvas
+  paint is GUI-verified (no headless unit test for Qt widgets).
+- **Hesiod end-to-end (controller build + user GUI):** the migrated Cloud node shows the
+  heightmap thumbnail behind the point editor, points are editable, the thumbnail refreshes when
+  the `background` input recomputes, and there is no crash.
+
+## 8. Branch & pin
+
+Continue on the existing branches: Meta commits on `external/Meta`'s `feature/meta-migration`
+(already pushed to otto-link/Meta), Hesiod commits on its `feature/meta-migration` (pushed to
+otto-link/Hesiod), bumping the `external/Meta` pin. No PR without explicit request.
+
+## 9. Components summary (isolation)
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `PointsCanvas::set_background_image` + paint | blit host image under the points | Qt |
+| `std_vector_glm_vec3.inl` PointsEditor wiring | read provider → feed the canvas image | PointsCanvas, `data_provider.hpp` |
+| Hesiod `cloud.cpp` provider | colorize `background` input → oriented `ProviderData.image_*` | HighMap colorize, all above |

--- a/docs/meta-migration/2026-07-11-data-provider-image-plan.md
+++ b/docs/meta-migration/2026-07-11-data-provider-image-plan.md
@@ -1,0 +1,260 @@
+# `ui.data_provider` image consumer (PointsCanvas background) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a live heightmap thumbnail behind Meta's `PointsCanvas`, fed by the existing `ui.data_provider` mechanism's `image_*` payload, verified by migrating one Hesiod Cloud node.
+
+**Architecture:** No Meta *core* change — `ProviderData.image_*` and the non-serializable `DataProvider` storage already exist (G1). Add a `set_background_image` + paint to `PointsCanvas`, read the provider in the `PointsEditor` renderer branch, and migrate `cloud.cpp` to Meta with an image data-provider (colorized `background` input).
+
+**Tech Stack:** C++20, Qt6, nlohmann_json. Libraries: `meta`, `meta_qt`. Spec: `docs/meta-migration/2026-07-11-data-provider-image-design.md`.
+
+## Global Constraints
+
+- No Meta core change: `meta::ProviderData` (with `image_width/height/channels/image_pixels`, `has_image()`), `meta::DataProvider`, `meta::keys::ui::data_provider`, and the `json_to` DataProvider skip already exist from G1. Do NOT re-add them.
+- Meta edits commit on `external/Meta`'s `feature/meta-migration` (already exists + pushed); Hesiod edits on Hesiod's `feature/meta-migration`. Bump the `external/Meta` pin in Hesiod. Do NOT push and do NOT open PRs unless explicitly asked.
+- Consumer scope: `PointsCanvas` background image only. No other widget.
+- Image is Qt-neutral: the host provider returns `image_pixels` (row-major, channel-interleaved) already oriented to the canvas (the Hesiod provider applies the vertical flip the legacy helper did); `PointsCanvas` just blits them scaled to its canvas rect.
+- Build env (repo precedent): build via `nix develop ~/quixote#cpp-qt-desktop`, cap `-j4`, run detached (unbounded `-j` OOMs). GUI verification is user-driven.
+- Staging discipline: each commit stages ONLY its named files; the dirty `external/{GNode,GNodeGUI,HighMap}` submodules and untracked files must never be staged. Never `git add -A`/`.`.
+
+---
+
+## Task 1: `PointsCanvas::set_background_image` + paint
+
+**Files:**
+- Modify: `external/Meta/MetaUI/qt/include/meta_qt/widgets/points_canvas.hpp`
+- Modify: `external/Meta/MetaUI/qt/src/widgets/points_canvas.cpp` (`paintEvent`, ~line 236)
+
+**Interfaces:**
+- Produces: `void PointsCanvas::set_background_image(const std::vector<uint8_t> &pixels, int w, int h, int channels);` — stores the image (empty `pixels` clears it); `paintEvent` blits it under the points, scaled to the canvas rect.
+
+- [ ] **Step 1: Declare the setter + members in the header**
+
+In `points_canvas.hpp`: in `public:` add
+```cpp
+  void set_background_image(const std::vector<uint8_t> &pixels, int w, int h, int channels);
+```
+in `private:` (near `points_` / the other members) add
+```cpp
+  std::vector<uint8_t> bg_pixels_;
+  int                  bg_w_ = 0, bg_h_ = 0, bg_channels_ = 0;
+```
+Ensure `#include <vector>` and `#include <cstdint>` are present (add if missing).
+
+- [ ] **Step 2: Implement the setter**
+
+In `points_canvas.cpp` add:
+```cpp
+void PointsCanvas::set_background_image(const std::vector<uint8_t> &pixels,
+                                       int w, int h, int channels)
+{
+  this->bg_pixels_ = pixels;
+  this->bg_w_ = w;
+  this->bg_h_ = h;
+  this->bg_channels_ = channels;
+  this->update();
+}
+```
+
+- [ ] **Step 3: Blit the background in `paintEvent`**
+
+In `paintEvent` (`~line 236`), immediately AFTER the existing base fill
+`p.fillRect(rect(), palette().color(QPalette::Base));` (~line 244) and BEFORE any point/grid
+drawing, add:
+```cpp
+  if (!this->bg_pixels_.empty() && this->bg_w_ > 0 && this->bg_h_ > 0)
+  {
+    const QImage::Format fmt = (this->bg_channels_ == 4) ? QImage::Format_RGBA8888
+                             : (this->bg_channels_ == 1) ? QImage::Format_Grayscale8
+                                                         : QImage::Format_RGB888;
+    const QImage img(this->bg_pixels_.data(),
+                     this->bg_w_,
+                     this->bg_h_,
+                     this->bg_w_ * this->bg_channels_, // bytes per line
+                     fmt);
+    p.drawImage(this->canvas_rect(), img);
+  }
+```
+`QPainter p` and `canvas_rect()` already exist in this method. Add `#include <QImage>` to the
+file's includes if not already present (`<QPainter>` is at line 11).
+
+- [ ] **Step 4: Build `meta_qt` (controller runs it)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target meta_qt 2>&1 | tail -10'
+```
+Expected: `meta_qt` compiles + links (`libmeta_qt.a`).
+
+- [ ] **Step 5: Commit (Meta branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod/external/Meta
+git add MetaUI/qt/include/meta_qt/widgets/points_canvas.hpp MetaUI/qt/src/widgets/points_canvas.cpp
+git commit -m "feat(qt): PointsCanvas renders an optional background image behind the points"
+```
+
+---
+
+## Task 2: Wire the provider into the PointsEditor renderer
+
+**Files:**
+- Modify: `external/Meta/MetaUI/qt/include/meta_qt/widget_renderer_inl/std_vector_glm_vec3.inl`
+
+**Interfaces:**
+- Consumes: `PointsCanvas::set_background_image` (Task 1); `meta::keys::ui::data_provider`, `meta::DataProvider`, `meta::ProviderData` (G1).
+- Produces: a `PointsEditor`/`PathEditor` `std::vector<glm::vec3>` attribute with a `ui.data_provider` gets its `image_*` blitted behind the points on build.
+
+- [ ] **Step 1: Feed the provider after the canvas is built**
+
+In `std_vector_glm_vec3.inl`, after `layout->addWidget(canvas);` (~line 67, where `canvas` is the
+`PointsCanvas*` and `attr` is the attribute handle), add:
+```cpp
+      if (const auto *mp = attr.metadata().find(meta::keys::ui::data_provider))
+      {
+        if (const auto *dp = mp->try_cast<meta::Attribute<meta::DataProvider>>())
+        {
+          const meta::DataProvider &provider = dp->value();
+          if (provider)
+          {
+            try
+            {
+              meta::ProviderData d = provider();
+              if (d.has_image())
+                canvas->set_background_image(d.image_pixels,
+                                             d.image_width,
+                                             d.image_height,
+                                             d.image_channels);
+            }
+            catch (...)
+            {
+              // a faulty host provider must not crash the panel
+            }
+          }
+        }
+      }
+```
+Add includes to the `.inl`: `#include "meta/core/data_provider.hpp"` and
+`#include "meta/metadata/keys.hpp"` (if not already present). (Confirm the actual local names
+`canvas` and `attr` from the surrounding branch and use them verbatim.)
+
+- [ ] **Step 2: Build `meta_qt` (controller)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target meta_qt 2>&1 | tail -10'
+```
+Expected: `meta_qt` compiles + links.
+
+- [ ] **Step 3: Commit (Meta branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod/external/Meta
+git add MetaUI/qt/include/meta_qt/widget_renderer_inl/std_vector_glm_vec3.inl
+git commit -m "feat(qt): feed ui.data_provider image into the PointsEditor canvas background"
+```
+
+---
+
+## Task 3: Migrate Hesiod `cloud.cpp` + pin bump + build/GUI
+
+**Files:**
+- Modify: `Hesiod/src/model/nodes/nodes_function/cloud.cpp`
+- Modify: `external/Meta` gitlink (pin bump), committed on Hesiod's branch
+
+**Interfaces:**
+- Consumes: everything above (Meta branch tip).
+- Produces: a Cloud node whose cloud attribute is a Meta `PointsEditor` with a working
+  `ui.data_provider` image (colorized `background` input); the submodule pin advanced.
+
+- [ ] **Step 1: Rewrite `setup_cloud_node` against Meta**
+
+Replace the `--- Attributes` + `set_attr_ordered_key` + `setup_background_image_for_cloud_attribute`
+block with Meta authoring on `node.meta_group().current()`:
+```cpp
+  auto &c = node.meta_group().current();
+
+  auto *a = c.add<std::vector<glm::vec3>>(A_CLOUD, {});
+  a->metadata().try_add(meta::keys::ui::label, std::string("Cloud"));
+  a->metadata().try_add(meta::keys::ui::widget_type, std::string("PointsEditor"));
+  a->metadata().try_add(meta::keys::ui::category, std::string("Main"));
+  a->metadata().try_add(
+      meta::keys::ui::data_provider,
+      meta::DataProvider{
+          [&node, port_id = std::string(P_BACKGROUND)]() -> meta::ProviderData
+          {
+            meta::ProviderData d;
+            hmap::VirtualArray *p_in = node.get_value_ref<hmap::VirtualArray>(port_id);
+            if (!p_in)
+              return d;
+            const glm::ivec2 shape(256, 256);
+            hmap::Array array = p_in->to_array(shape, node.cfg().cm_cpu);
+            std::vector<uint8_t> img =
+                hmap::colorize(array, array.min(), array.max(), hmap::Cmap::MAGMA, false)
+                    .to_img_8bit();
+            d.image_width = shape.x;
+            d.image_height = shape.y;
+            d.image_channels = 3; // to_img_8bit() -> RGB
+            // vertical flip so the thumbnail origin matches the canvas (legacy mirrored(false,true))
+            const int stride = shape.x * 3;
+            d.image_pixels.resize(img.size());
+            for (int y = 0; y < shape.y; ++y)
+              std::copy_n(img.data() + (shape.y - 1 - y) * stride,
+                          stride,
+                          d.image_pixels.data() + y * stride);
+            return d;
+          }});
+```
+Add includes: `#include "highmap/colorize.hpp"`, `#include "highmap/operator.hpp"`,
+`#include "highmap/virtual_array/virtual_array.hpp"`, `#include "meta/core/data_provider.hpp"`,
+`#include "meta/metadata/keys.hpp"`, and `#include <algorithm>` (for `std::copy_n`). Drop the
+`#include "attributes.hpp"` + `using namespace attr;` if nothing else in the file uses `attr::`.
+
+- [ ] **Step 2: Update `compute_cloud_node` to read from Meta**
+
+Replace `const auto cloud_attr = node.get_attr<CloudAttribute>(A_CLOUD);` with:
+```cpp
+  const auto cloud_attr = node.meta_group().current().value<std::vector<glm::vec3>>(A_CLOUD);
+```
+The next line `*p_out = hmap::Cloud(cloud_attr);` is unchanged (`hmap::Cloud` accepts a
+`std::vector<glm::vec3>`).
+
+- [ ] **Step 3: Bump the Hesiod submodule pin**
+
+```bash
+cd /home/barrulus/dev/Hesiod
+git -C external/Meta rev-parse --short HEAD   # Meta branch tip (note it)
+git add external/Meta
+```
+
+- [ ] **Step 4: Build Hesiod (controller, detached)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target hesiod 2>&1 | tail -20; echo EXIT=${PIPESTATUS[0]}'
+```
+Expected: `Linking CXX executable ... bin/hesiod`, `EXIT=0`. (Run in background per env notes.)
+
+- [ ] **Step 5: Commit (Hesiod branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod
+git add external/Meta Hesiod/src/model/nodes/nodes_function/cloud.cpp
+git commit -m "feat(meta): bump Meta pin; verify ui.data_provider image on Cloud PointsEditor"
+```
+
+- [ ] **Step 6: GUI verification (user-driven)**
+
+Launch `build/bin/hesiod`. Add a **Noise** node → connect it to the Cloud node's **background**
+input. Confirm:
+1. The Cloud node's editor shows the **heightmap thumbnail behind the points**, aligned with the
+   point coordinates (not upside-down).
+2. It **refreshes** when the upstream Noise recomputes.
+3. Points are **editable** (add/drag), and edits commit on release (recompute on `edit_ended`).
+4. No crash.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** §3.1 PointsCanvas (Task 1), §3.2 renderer wiring (Task 2), §5 Hesiod node + §4 orientation flip (Task 3), §8 pin bump (Task 3). §2 (no core change) is honored — no core files touched. §7 testing = `meta_qt` build (Tasks 1-2) + Hesiod build + GUI (Task 3); no new Meta unit test since core is unchanged.
+- **Placeholder scan:** none — every step has concrete code/commands.
+- **Type consistency:** `set_background_image(pixels, w, h, channels)` (Task 1) is called with exactly those args from Task 2 and fed `ProviderData.image_pixels/width/height/channels` from Task 3. `A_CLOUD` and `P_BACKGROUND` are the existing `constexpr` names in `cloud.cpp`.
+- **External-API confirmations flagged:** the `canvas`/`attr` local names (Task 2), the `paintEvent` insertion point and `QImage` includes (Task 1), and `to_img_8bit()` returning RGB (Task 3) are each directed to the actual source to confirm, not invented.

--- a/docs/meta-migration/2026-07-12-panel-refresh-sync-design.md
+++ b/docs/meta-migration/2026-07-12-panel-refresh-sync-design.md
@@ -1,0 +1,129 @@
+# Meta panel refresh: sync-not-rebuild + live preview — Design
+
+**Date:** 2026-07-12
+**Repos:** `otto-link/Meta` + `otto-link/Hesiod`
+**Status:** Design approved; ready for implementation plan.
+**Context:** "Refresh approach #1", deferred from the G1 drag fix (`docs/meta-migration/2026-07-10-*`).
+Replaces the pragmatic `edit_ended` workaround with the proper refresh architecture: meta-backed
+node panels **sync** their live widgets from the model on recompute instead of being torn down and
+rebuilt, enabling **live preview during drag** and refreshing data-providers without re-running
+them every frame.
+
+## 1. Goal
+
+When a meta-backed node's settings panel is open and the graph recomputes, refresh the widgets by
+**syncing them from the model** (keeping them alive) rather than destroying and rebuilding the whole
+panel. This (a) enables live terrain preview while dragging a control, (b) stops the full-rebuild
+cost per recompute, and (c) keeps data-provider previews (histogram, thumbnail) fresh on genuine
+upstream changes while **not** re-running the expensive provider on every frame of a self-drag.
+
+## 2. Background — why the current path forces a rebuild
+
+- `NodeSettingsWidget::setup_connections` wires **both** `GraphViewer::selection_has_changed` and
+  `GraphNodeWidget::update_finished` → `NodeSettingsWidget::update_content`
+  (`node_settings_widget.cpp:44-52`), and `update_content` calls `clear_layout(attr_layout)` then
+  recreates a `NodeAttributesWidget` per displayed node (`:92`, `:156`). So every recompute rebuilds
+  the panel.
+- Meta already provides the sync machinery — `MetaWidget::set_sync_from_model(std::function<void()>)`
+  / `sync_widget_from_model()`, and `ContainerGroupWidget::on_sync_meta_widgets_from_model()` which
+  fans out to each contained `MetaWidget`. **But** the per-widget sync callbacks (e.g. the RangeBar's
+  in `glm_vec2.inl`) only `set_value` — they do not re-pull the `ui.data_provider`, so a sync alone
+  would leave the histogram/thumbnail stale.
+- The G1 fix wired meta recompute to `edit_ended` (commit-on-release) to avoid destroying a
+  live-dragged widget. That works but gives no live preview and still rebuilds on every commit.
+
+## 3. Components
+
+### 3.1 Meta core — `MetaWidget` edit state (`meta_qt/meta_widget.{hpp,cpp}`)
+- Add `bool editing_ = false;` + `bool is_editing() const;`.
+- In the `MetaWidget` constructor, self-connect: `edit_started` → `editing_ = true`;
+  `edit_ended` → `editing_ = false`. (These signals are already emitted by the renderer wiring.)
+- Purpose: let a sync callback distinguish "this widget is mid-edit (a drag)" from "an upstream
+  change triggered the sync".
+
+### 3.2 Meta — provider re-pull on sync, guarded by edit state
+- **RangeBar** (`glm_vec2.inl`, the `set_sync_from_model` lambda ~line 298): after the existing
+  `bar->set_value(value)`, add — if a `ui.data_provider` is present on `attr` **and**
+  `!widget->is_editing()` → call the provider and `bar->set_histogram(d.series_x, d.series_y)` when
+  `d.has_series()`, in a try/catch. Capture a copy of the `meta::DataProvider` (read once at render)
+  in the sync lambda so no per-sync `find`/`try_cast` is needed.
+- **PointsEditor** (`std_vector_glm_vec3.inl`): ensure the branch installs a `set_sync_from_model`
+  callback that syncs the points from the model (`canvas->set_points(value)`) and, when
+  `!widget->is_editing()` and a provider is present, re-pulls it → `canvas->set_background_image(...)`
+  when `d.has_image()`. (If the branch has no sync callback today, add one.)
+- Effect: on an upstream change the previews refresh; during a self-drag they are held (cheap).
+
+### 3.3 Hesiod — `NodeAttributesWidget` sync entry point
+- Store the meta panel widget as a member (it is currently a local in `setup_layout`):
+  `meta::qt::ContainerGroupWidget *meta_widget = nullptr;` (set in the `uses_meta()` branch).
+- Add `void sync_from_model();` — if `meta_widget` is non-null,
+  `meta_widget->on_sync_meta_widgets_from_model()`; otherwise no-op (legacy `attr::AttributesWidget`
+  values are the source of truth and do not change on recompute).
+- Add `bool is_meta_backed() const { return this->meta_widget != nullptr; }`.
+
+### 3.4 Hesiod — `NodeSettingsWidget` sync-not-rebuild path
+- Keep the created `NodeAttributesWidget`s alive: store them (e.g. `std::vector<QPointer<NodeAttributesWidget>>`)
+  as `update_content` builds them.
+- Split the refresh:
+  - `selection_has_changed` → `update_content` (full rebuild — unchanged).
+  - `update_finished` → a **new** `sync_content()`.
+- `sync_content()`: if **every** currently-displayed `NodeAttributesWidget` `is_meta_backed()`, call
+  `sync_from_model()` on each (no teardown). If **any** is legacy, fall back to `update_content()`
+  (full rebuild — preserves current legacy behavior). Settings panels usually show a single node, so
+  the pure-meta case (the migration target) is the common one.
+
+### 3.5 Hesiod — revert the recompute trigger
+- In `NodeAttributesWidget`'s `uses_meta()` branch, change the recompute connection from
+  `meta::qt::MetaWidget::edit_ended` back to `meta::qt::MetaWidget::value_changed` (continuous), so
+  dragging streams recompute for live preview. Safe now: sync-not-rebuild keeps the widget alive.
+
+## 4. Data flow
+
+**Dragging a RangeBar handle (live preview):**
+1. Drag → RangeBar `value_changed` (continuous) → panel `value_changed` → `gno->update()` (recompute).
+2. recompute → `update_finished` → `NodeSettingsWidget::sync_content` → (pure-meta) each
+   `NodeAttributesWidget::sync_from_model` → `ContainerGroupWidget::on_sync_meta_widgets_from_model`
+   → each widget's sync callback.
+3. The dragged RangeBar's sync: `set_value(value)` (no-op — the drag already set it) and, because
+   `widget->is_editing()`, **skips** the histogram re-pull. The widget is not destroyed; the terrain
+   preview updates live.
+4. On release: `edit_ended` → `editing_ = false`. The next sync (or any upstream-triggered recompute)
+   has `!is_editing()` → **re-pulls** the provider → fresh histogram.
+5. Upstream node changes with no active edit → recompute → sync → `!is_editing()` → provider re-pull
+   → histogram/thumbnail refresh.
+
+## 5. Error handling / edge cases
+
+- A displayed node deleted mid-session → `selection_has_changed` fires → full `update_content`; a
+  `QPointer` guard skips any widget that became null before `sync_content` runs.
+- A faulty/throwing provider during a sync re-pull → caught in the sync callback's try/catch → the
+  preview is simply not updated that cycle (no crash).
+- Legacy or mixed panels → `sync_content` falls back to `update_content`; no behavior change.
+- `is_editing()` defaults false; if `edit_started`/`edit_ended` are ever unbalanced, the worst case is
+  a redundant provider re-pull (correct, just not optimal).
+
+## 6. Testing
+
+- **Meta core:** unit assertion — a `MetaWidget` reports `is_editing()==false` initially, `true` after
+  `edit_started`, `false` after `edit_ended` (drive the signals directly). Build `meta_qt`.
+- **Hesiod:** build. GUI (user):
+  1. Drag a `Saturate` range handle → terrain updates **live during the drag** (not only on release);
+     the histogram does not stutter/flash while dragging.
+  2. Change the upstream node → the Saturate histogram and the Cloud thumbnail **refresh**.
+  3. A legacy (non-migrated) node's panel behaves exactly as before.
+  4. No crash; selecting a different node still rebuilds correctly.
+
+## 7. Branch & pin
+
+Continue on the existing `feature/meta-migration` branches (Meta commits + Hesiod pin bump). No PR
+without explicit request.
+
+## 8. Components summary (isolation)
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `MetaWidget::is_editing` | expose mid-edit state from edit_started/ended | Qt signals |
+| RangeBar/PointsEditor sync re-pull | refresh preview from provider unless mid-edit | is_editing, data_provider |
+| `NodeAttributesWidget::sync_from_model` | forward sync to the meta panel | ContainerGroupWidget |
+| `NodeSettingsWidget::sync_content` | sync alive widgets on recompute; rebuild only on selection / legacy | NodeAttributesWidget |
+| recompute trigger revert | continuous value_changed for live preview | sync-not-rebuild keeping widgets alive |

--- a/docs/meta-migration/2026-07-12-panel-refresh-sync-plan.md
+++ b/docs/meta-migration/2026-07-12-panel-refresh-sync-plan.md
@@ -1,0 +1,314 @@
+# Meta panel refresh: sync-not-rebuild + live preview — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh meta-backed node panels by syncing live widgets from the model on recompute (keeping them alive) instead of rebuilding, enabling live drag preview while re-pulling data-providers only on genuine upstream changes.
+
+**Architecture:** `MetaWidget` gains an `is_editing()` flag (from its own `edit_started`/`edit_ended`). The RangeBar/PointsEditor sync callbacks re-pull their `ui.data_provider` unless mid-edit. Hesiod keeps `NodeAttributesWidget`s alive and, on `update_finished`, syncs them (pure-meta panels) instead of rebuilding; the meta recompute trigger reverts to continuous `value_changed`.
+
+**Tech Stack:** C++20, Qt6. Libraries: `meta_qt` (Meta Qt backend), Hesiod GUI. Spec: `docs/meta-migration/2026-07-12-panel-refresh-sync-design.md`.
+
+## Global Constraints
+
+- Meta edits commit on `external/Meta`'s `feature/meta-migration`; Hesiod edits on Hesiod's `feature/meta-migration`; bump the `external/Meta` pin in Hesiod. Do NOT push, do NOT open PRs unless explicitly asked.
+- The provider re-pull on sync MUST be skipped while the widget `is_editing()` (a self-drag), so the expensive provider does not run every drag frame; it re-pulls when `!is_editing()` (upstream change or drag release).
+- Legacy / mixed panels must be untouched: `sync_content()` syncs only when EVERY displayed `NodeAttributesWidget` is meta-backed; otherwise it falls back to a full `update_content()` rebuild.
+- Build env (repo precedent): build via `nix develop ~/quixote#cpp-qt-desktop`, cap `-j4`, run detached. GUI verification is user-driven.
+- Staging discipline: each commit stages ONLY its named files; the dirty `external/{GNode,GNodeGUI,HighMap}` submodules and untracked files must never be staged. Never `git add -A`/`.`.
+
+---
+
+## Task 1: `MetaWidget::is_editing()` (Meta)
+
+**Files:**
+- Modify: `external/Meta/MetaUI/qt/include/meta_qt/meta_widget.hpp`
+- Modify: `external/Meta/MetaUI/qt/src/meta_widget.cpp`
+
+**Interfaces:**
+- Produces: `bool MetaWidget::is_editing() const;` — true between an `edit_started` and the matching `edit_ended`.
+
+- [ ] **Step 1: Declare `is_editing()` + the flag**
+
+In `meta_widget.hpp`: in `public:` add `bool is_editing() const;`. In `private:` (next to `std::function<void()> sync_from_model_;`) add `bool editing_ = false;`.
+
+- [ ] **Step 2: Self-connect the edit signals in the constructor**
+
+Read `meta_widget.cpp` and `meta_widget.hpp` to find the constructor. If a `MetaWidget(QWidget *parent)` constructor body exists, add to it; if the ctor is implicit/defaulted, add an explicit `MetaWidget::MetaWidget(QWidget *parent) : QWidget(parent) { ... }` (declare it in the header `public:` as `MetaWidget(QWidget *parent = nullptr);` if not already declared). In the ctor body add:
+```cpp
+  QObject::connect(this, &MetaWidget::edit_started, this, [this]() { this->editing_ = true; });
+  QObject::connect(this, &MetaWidget::edit_ended, this, [this]() { this->editing_ = false; });
+```
+And define the getter in the `.cpp`:
+```cpp
+bool MetaWidget::is_editing() const { return this->editing_; }
+```
+(Confirm whether an explicit ctor already exists before adding one, to avoid a duplicate-definition error.)
+
+- [ ] **Step 3: Build `meta_qt` (controller)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target meta_qt 2>&1 | tail -8'
+```
+Expected: compiles + links.
+
+- [ ] **Step 4: Commit (Meta branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod/external/Meta
+git add MetaUI/qt/include/meta_qt/meta_widget.hpp MetaUI/qt/src/meta_widget.cpp
+git commit -m "feat(qt): MetaWidget tracks edit state via is_editing()"
+```
+
+---
+
+## Task 2: Re-pull data-providers on sync, guarded by `is_editing()` (Meta)
+
+**Files:**
+- Modify: `external/Meta/MetaUI/qt/include/meta_qt/widget_renderer_inl/glm_vec2.inl` (RangeBar branch)
+- Modify: `external/Meta/MetaUI/qt/include/meta_qt/widget_renderer_inl/std_vector_glm_vec3.inl` (PointsEditor branch)
+
+**Interfaces:**
+- Consumes: `MetaWidget::is_editing()` (Task 1); the existing `set_histogram` / `set_background_image` (G1/G2); the `ui.data_provider` metadata.
+- Produces: on a model sync, a RangeBar/PointsEditor whose attribute has a `ui.data_provider` re-pulls it and refreshes its preview — but only when `!widget->is_editing()`.
+
+- [ ] **Step 1: RangeBar — capture the provider and re-pull it in the sync callback**
+
+In `glm_vec2.inl`, the `RangeBar` branch already reads the provider for the initial `set_histogram`
+(the `find` + `try_cast<meta::Attribute<meta::DataProvider>>` block from G1). Refactor so the provider
+is stored in a branch-scope copy usable by the sync lambda:
+```cpp
+      meta::DataProvider range_provider; // empty if none
+      if (const auto *mp = attr.metadata().find(meta::keys::ui::data_provider))
+        if (const auto *dp = mp->try_cast<meta::Attribute<meta::DataProvider>>())
+          range_provider = dp->value();
+
+      if (range_provider)
+        try { meta::ProviderData d = range_provider(); if (d.has_series()) bar->set_histogram(d.series_x, d.series_y); }
+        catch (...) {}
+```
+Then in the `widget->set_sync_from_model([...]() { ... })` lambda, add `widget` and `range_provider`
+to the capture list, and AFTER the existing `bar->set_value(value)` block add:
+```cpp
+            if (range_provider && !widget->is_editing())
+            {
+              try
+              {
+                meta::ProviderData d = range_provider();
+                if (d.has_series())
+                  bar->set_histogram(d.series_x, d.series_y);
+              }
+              catch (...) {}
+            }
+```
+
+- [ ] **Step 2: PointsEditor — re-pull the image in its existing sync callback**
+
+In `std_vector_glm_vec3.inl`, the PointsEditor branch already has
+`widget->set_sync_from_model([...]() { canvas->set_points(value); })` and, from G2, reads the provider
+for the initial `set_background_image`. Store the provider in a branch-scope copy the same way:
+```cpp
+      meta::DataProvider points_provider;
+      if (const auto *mp = attr.metadata().find(meta::keys::ui::data_provider))
+        if (const auto *dp = mp->try_cast<meta::Attribute<meta::DataProvider>>())
+          points_provider = dp->value();
+```
+(and use it for the existing initial `set_background_image`). Then add `widget` and `points_provider`
+to the sync lambda's capture list and, after `canvas->set_points(value);`, add:
+```cpp
+            if (points_provider && !widget->is_editing())
+            {
+              try
+              {
+                meta::ProviderData d = points_provider();
+                if (d.has_image())
+                  canvas->set_background_image(d.image_pixels, d.image_width, d.image_height, d.image_channels);
+              }
+              catch (...) {}
+            }
+```
+
+- [ ] **Step 3: Build `meta_qt` (controller)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target meta_qt 2>&1 | tail -8'
+```
+Expected: compiles + links.
+
+- [ ] **Step 4: Commit (Meta branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod/external/Meta
+git add MetaUI/qt/include/meta_qt/widget_renderer_inl/glm_vec2.inl MetaUI/qt/include/meta_qt/widget_renderer_inl/std_vector_glm_vec3.inl
+git commit -m "feat(qt): re-pull ui.data_provider on sync unless the widget is mid-edit"
+```
+
+---
+
+## Task 3: `NodeAttributesWidget` — sync entry point + revert trigger (Hesiod)
+
+**Files:**
+- Modify: `Hesiod/include/hesiod/gui/widgets/node_attributes_widget.hpp`
+- Modify: `Hesiod/src/gui/widgets/node_attributes_widget.cpp`
+
+**Interfaces:**
+- Consumes: `meta::qt::ContainerGroupWidget::on_sync_meta_widgets_from_model()`.
+- Produces:
+  - `void NodeAttributesWidget::sync_from_model();` — syncs the meta panel from the model (no-op for legacy).
+  - `bool NodeAttributesWidget::is_meta_backed() const;`
+
+- [ ] **Step 1: Add the member + method declarations to the header**
+
+In `node_attributes_widget.hpp`: add `#include "meta_qt/container_group_widget.hpp"` (near the other includes). In `public:` add:
+```cpp
+  void sync_from_model();
+  bool is_meta_backed() const;
+```
+In `private:` add:
+```cpp
+  meta::qt::ContainerGroupWidget *meta_widget = nullptr;
+```
+
+- [ ] **Step 2: Store the meta widget in `setup_layout`**
+
+In `node_attributes_widget.cpp`, in the `if (p_node->uses_meta())` branch, change the local
+`auto *meta_widget = new meta::qt::ContainerGroupWidget(...)` to assign the member:
+```cpp
+    this->meta_widget = new meta::qt::ContainerGroupWidget(p_node->meta_group(),
+                                                           meta::qt::ContainerRenderOptions{},
+                                                           this);
+```
+and use `this->meta_widget` in the rest of that branch (the `connect(...)` and `addWidget(...)`).
+
+- [ ] **Step 3: Revert the recompute trigger to `value_changed`**
+
+In that same branch, change the recompute connection signal from
+`&meta::qt::MetaWidget::edit_ended` back to `&meta::qt::MetaWidget::value_changed` (the lambda body —
+`p_graph_node.lock()` → `gno->update(node_id)` — is unchanged). Update the adjacent comment to note
+recompute is continuous again (safe because the panel now syncs instead of rebuilding).
+
+- [ ] **Step 4: Define `sync_from_model()` and `is_meta_backed()`**
+
+In `node_attributes_widget.cpp` add:
+```cpp
+void NodeAttributesWidget::sync_from_model()
+{
+  if (this->meta_widget)
+    this->meta_widget->on_sync_meta_widgets_from_model();
+  // legacy attr::AttributesWidget: values are the source of truth, no model sync needed.
+}
+
+bool NodeAttributesWidget::is_meta_backed() const { return this->meta_widget != nullptr; }
+```
+
+- [ ] **Step 5: Commit (Hesiod branch) — no build yet (controller builds after Task 4)**
+
+```bash
+cd /home/barrulus/dev/Hesiod
+git add Hesiod/include/hesiod/gui/widgets/node_attributes_widget.hpp Hesiod/src/gui/widgets/node_attributes_widget.cpp
+git commit -m "feat(meta): NodeAttributesWidget exposes sync_from_model + is_meta_backed; recompute on value_changed"
+```
+
+---
+
+## Task 4: `NodeSettingsWidget` — sync-not-rebuild + pin bump + build/GUI (Hesiod)
+
+**Files:**
+- Modify: `Hesiod/include/hesiod/gui/widgets/node_settings_widget.hpp`
+- Modify: `Hesiod/src/gui/widgets/node_settings_widget.cpp`
+- Modify: `external/Meta` gitlink (pin bump), committed on Hesiod's branch
+
+**Interfaces:**
+- Consumes: `NodeAttributesWidget::sync_from_model()` / `is_meta_backed()` (Task 3); the Meta branch tip (Tasks 1-2).
+- Produces: on recompute, pure-meta panels sync in place; selection change and legacy/mixed panels still rebuild.
+
+- [ ] **Step 1: Add the widget list + `sync_content()` declaration**
+
+In `node_settings_widget.hpp`: add `#include "hesiod/gui/widgets/node_attributes_widget.hpp"` (forward-decl is insufficient — we call methods). In `private:` add:
+```cpp
+  std::vector<QPointer<NodeAttributesWidget>> attr_widgets;
+  void                                        sync_content();
+```
+
+- [ ] **Step 2: Record each `NodeAttributesWidget` as `update_content` builds it**
+
+In `node_settings_widget.cpp::update_content`, clear the list at the top (right after
+`clear_layout(this->attr_layout);`): `this->attr_widgets.clear();`. Where the loop creates
+`auto *attr_widget = new NodeAttributesWidget(...)`, after adding it to the layout, record it:
+```cpp
+    this->attr_widgets.push_back(attr_widget);
+```
+
+- [ ] **Step 3: Implement `sync_content()` with the mixed-panel fallback**
+
+Add:
+```cpp
+void NodeSettingsWidget::sync_content()
+{
+  Logger::log()->trace("NodeSettingsWidget::sync_content");
+
+  // Rebuild if the panel is empty or contains any legacy (non-meta) widget.
+  if (this->attr_widgets.empty())
+  {
+    this->update_content();
+    return;
+  }
+  for (const auto &w : this->attr_widgets)
+    if (!w || !w->is_meta_backed())
+    {
+      this->update_content();
+      return;
+    }
+
+  // Pure-meta panel: sync in place, no teardown.
+  for (const auto &w : this->attr_widgets)
+    if (w)
+      w->sync_from_model();
+}
+```
+
+- [ ] **Step 4: Route `update_finished` to `sync_content` (keep selection → rebuild)**
+
+In `NodeSettingsWidget::setup_connections`, change the second connection: `GraphNodeWidget::update_finished`
+should connect to `&NodeSettingsWidget::sync_content` (NOT `update_content`). Leave the
+`selection_has_changed → update_content` connection unchanged.
+
+- [ ] **Step 5: Bump the Hesiod submodule pin to the Meta branch tip**
+
+```bash
+cd /home/barrulus/dev/Hesiod
+git -C external/Meta rev-parse --short HEAD   # Meta tip after Tasks 1-2 (note it)
+git add external/Meta
+```
+
+- [ ] **Step 6: Build Hesiod (controller, detached)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target hesiod 2>&1 | tail -20; echo EXIT=${PIPESTATUS[0]}'
+```
+Expected: `Linking CXX executable ... bin/hesiod`, `EXIT=0`. (Run in background per env notes.)
+
+- [ ] **Step 7: Commit (Hesiod branch)**
+
+```bash
+cd /home/barrulus/dev/Hesiod
+git add external/Meta Hesiod/include/hesiod/gui/widgets/node_settings_widget.hpp Hesiod/src/gui/widgets/node_settings_widget.cpp
+git commit -m "feat(meta): sync meta panels on recompute instead of rebuilding; bump Meta pin"
+```
+
+- [ ] **Step 8: GUI verification (user-driven)**
+
+Launch `build/bin/hesiod`. Then:
+1. `Noise → Saturate`, select Saturate, **drag a range handle** → the terrain preview updates **live while dragging** (not only on release); the histogram behind the handles does not stutter/flash during the drag.
+2. Change the upstream `Noise` (seed/type) → the Saturate **histogram refreshes**.
+3. `Noise → Cloud` (background) → change the Noise → the Cloud **thumbnail refreshes**.
+4. Select a **legacy (non-migrated) node** → its panel behaves exactly as before; switching selection rebuilds correctly.
+5. No crash.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** §3.1 (Task 1), §3.2 (Task 2), §3.3 + §3.5 (Task 3), §3.4 (Task 4). §4 data flow is realized by Tasks 2-4 together. §6 testing = `meta_qt` builds (Tasks 1-2), Hesiod build + GUI (Task 4).
+- **Placeholder scan:** none — concrete code/commands throughout. The one conditional (does `MetaWidget` have an explicit ctor) is directed to confirm against the source, not left vague.
+- **Type consistency:** `is_editing()` (Task 1) is used verbatim in Task 2's guards; `sync_from_model()`/`is_meta_backed()` (Task 3) are called verbatim in Task 4's `sync_content`; `meta_widget` member name consistent Task 3 → its usage; `attr_widgets` consistent Task 4.
+- **External-API confirmations flagged:** the `MetaWidget` ctor existence (Task 1), the exact RangeBar/PointsEditor sync-lambda capture lists (Task 2), and the `update_content` creation site (Task 4) are each directed to the real source to confirm.

--- a/docs/meta-migration/2026-07-13-settings-panel-resizable-design.md
+++ b/docs/meta-migration/2026-07-13-settings-panel-resizable-design.md
@@ -1,0 +1,94 @@
+# Resizable node-settings panel (+ scroll fallback) — Design
+
+**Date:** 2026-07-13
+**Repo:** `otto-link/Hesiod` (Hesiod-side only)
+**Status:** Design approved; ready for implementation plan.
+**Context:** Deferred finding from the Meta migration — Meta node panels clip because the settings
+panel is hard-fixed at 360px (`node_settings_widget.cpp:28-29`, `// TODO fix this`) with horizontal
+scroll off. Widest offender: the `kw` paired sliders (`LinkedSliders`) exceed 360px and drag the
+whole container wide, clipping every input.
+
+## 1. Goal
+
+Make the node-settings panel **user-resizable** with a comfortable default width, and never clip its
+contents (scroll as a last resort). This is a Hesiod-side layout fix; it does not touch Meta.
+
+## 2. Scope
+
+**In scope:** the settings panel's width behaviour — a horizontal splitter, removing the hard cap,
+and a horizontal-scroll fallback.
+
+**Explicitly out of scope (deferred):** the Meta-side widget sizing (Meta's `SliderFloat`/`SliderInt`
+`minimumWidth` making the widgets wide in the first place) — that's Otto's library and a separate
+question. This fix resolves the clipping without it. Also out: persisting the splitter position
+across sessions (YAGNI).
+
+## 3. Current layout
+
+`GraphEditorWidget::setup_layout` (`graph_editor_widget.cpp`, ~line 130-180) uses a `QGridLayout`:
+- `node_library_widget` at grid `(0, 0, 2, 1)`.
+- a **vertical** `QSplitter` holding `viewer` + `graph_node_widget` at `(0, row_offset)`, with
+  `graph_toolbar` at `(1, row_offset)`.
+- `node_settings_widget` at `(0, row_offset + 1, 2, 1)`.
+
+`NodeSettingsWidget` fixes its own width: `setMinimumWidth(360); setMaximumWidth(360);`
+(`node_settings_widget.cpp:28-29`). Its internal scroll area is `setWidgetResizable(true)` with
+`setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff)` (`:75-77`).
+
+## 4. Changes
+
+### 4.1 `graph_editor_widget.cpp` — horizontal splitter
+Introduce a **horizontal** `QSplitter` that holds two panes:
+- **Pane 1 (graph area):** a container holding the existing vertical viewer/graph splitter and the
+  graph toolbar (currently the `row_offset` grid column's contents). Wrap those into one widget/layout
+  so they can live in a single splitter pane.
+- **Pane 2:** `node_settings_widget`.
+
+Place this horizontal splitter in the grid where the graph column + settings column previously sat
+(the grid becomes `[node_library | horizontal_splitter]`). Set initial pane sizes with
+`splitter->setSizes({<graph_large>, <settings_default>})` so the graph gets the majority and the
+settings panel opens around ~400px, and set stretch factors so the graph pane absorbs most window
+resizing (`setStretchFactor(0, 1)` graph, `setStretchFactor(1, 0)` settings).
+
+### 4.2 `node_settings_widget.cpp` — remove the hard cap
+Replace `setMinimumWidth(360); setMaximumWidth(360);` with a modest floor and no ceiling:
+`setMinimumWidth(320);` (no `setMaximumWidth`). The splitter now governs the actual width.
+
+### 4.3 `node_settings_widget.cpp` — scroll fallback
+Change `scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);` →
+`Qt::ScrollBarAsNeeded;` so contents wider than the current panel width scroll rather than clip.
+
+## 5. Behaviour / data flow
+
+- The panel opens at its default splitter width (~400px). The user drags the splitter handle to
+  widen it for control-heavy nodes (e.g. a node with paired `kw` sliders) or narrow it to reclaim
+  graph space.
+- If the panel is narrower than a node's widgets need, a horizontal scrollbar appears inside the
+  settings scroll area instead of clipping.
+- The graph/viewer area keeps its existing vertical splitter behaviour, now nested inside the new
+  horizontal splitter.
+
+## 6. Error handling / edge cases
+
+- Dragging the settings pane to its minimum (`320px`) is bounded by `setMinimumWidth`; it cannot
+  collapse to zero.
+- The node-library column is unchanged (still its own grid column, not in the splitter).
+- No persistence: the splitter resets to its default sizes on each launch (acceptable; a
+  session-persistence enhancement is deferred).
+
+## 7. Testing
+
+Build; GUI (user):
+1. The settings panel opens at a comfortable width (~400px), and a `kw`/`LinkedSliders` node's
+   inputs are **not clipped** at the default width.
+2. Dragging the splitter handle **widens/narrows** the panel smoothly; the graph area takes the rest.
+3. Dragging the panel narrower than its content shows a **horizontal scrollbar** (no clip).
+4. The viewer/graph vertical splitter still works; the node library is unaffected; no crash.
+
+## 8. Components summary (isolation)
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `GraphEditorWidget` layout | host graph-area + settings in a resizable horizontal splitter | QSplitter |
+| `NodeSettingsWidget` width | min-only width (no hard cap); splitter governs actual width | the splitter |
+| settings scroll area | scroll horizontally when content exceeds the panel width | Qt scroll area |

--- a/docs/meta-migration/2026-07-13-settings-panel-resizable-plan.md
+++ b/docs/meta-migration/2026-07-13-settings-panel-resizable-plan.md
@@ -1,0 +1,135 @@
+# Resizable node-settings panel (+ scroll fallback) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Hesiod's node-settings panel user-resizable (horizontal splitter, ~400px default) and never clip its contents, replacing the hard-coded 360px cap.
+
+**Architecture:** Wrap the graph area (the existing vertical viewer/graph splitter + the graph toolbar) and the settings panel in a new horizontal `QSplitter`; drop `NodeSettingsWidget`'s `min==max==360` to a min-only floor; set its scroll area to `ScrollBarAsNeeded`. Hesiod-side only; Meta untouched.
+
+**Tech Stack:** C++20, Qt6 (QSplitter, QVBoxLayout, QGridLayout). Spec: `docs/meta-migration/2026-07-13-settings-panel-resizable-design.md`.
+
+## Global Constraints
+
+- Hesiod-side only (`otto-link/Hesiod`, branch `feature/meta-migration`). No Meta change, no submodule pin change. Do NOT push / open PRs unless explicitly asked.
+- Deferred (do NOT do here): Meta-side widget `minimumWidth` sizing; splitter-position persistence.
+- Build env (repo precedent): build via `nix develop ~/quixote#cpp-qt-desktop`, cap `-j4`, run detached. GUI verification is user-driven.
+- Staging discipline: stage ONLY the two named files; never `git add -A`/`.`; the dirty `external/{GNode,GNodeGUI,HighMap}` submodules and untracked files must never be staged.
+
+---
+
+## Task 1: Resizable settings panel via a horizontal splitter
+
+**Files:**
+- Modify: `Hesiod/src/gui/widgets/graph_editor_widget.cpp` (`setup_layout`, ~lines 140-180)
+- Modify: `Hesiod/src/gui/widgets/node_settings_widget.cpp` (width cap ~lines 28-29; scroll policy ~line 75)
+
+**Interfaces:** none consumed/produced across tasks (single self-contained layout change).
+
+- [ ] **Step 1: Remove the hard width cap in `node_settings_widget.cpp`**
+
+Replace the fixed cap (currently `this->setMinimumWidth(360); this->setMaximumWidth(360);`, ~line 28-29) with a min-only floor:
+```cpp
+  this->setMinimumWidth(320); // splitter governs the actual width; never collapses below this
+```
+(Delete the `setMaximumWidth(360)` line entirely.)
+
+- [ ] **Step 2: Set the scroll-area horizontal policy to AsNeeded**
+
+In `node_settings_widget.cpp`, change (~line 75):
+```cpp
+    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+```
+to:
+```cpp
+    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+```
+
+- [ ] **Step 3: Restructure `graph_editor_widget.cpp` into a horizontal splitter**
+
+Read `setup_layout` (~lines 122-180). Replace the three blocks — `// left pan with splitter`, `// right pan`, and `// bottom toolbar` (the current lines ~140-180) — with a graph container + a horizontal splitter. Keep the `// optional left pan for node library` block above unchanged. New code:
+```cpp
+  // graph area: viewer/graph vertical splitter + toolbar, wrapped so it can be
+  // one pane of the horizontal splitter below.
+  QWidget     *graph_container = new QWidget();
+  QVBoxLayout *graph_layout = new QVBoxLayout(graph_container);
+  graph_layout->setContentsMargins(0, 0, 0, 0);
+  graph_layout->setSpacing(0);
+
+  {
+    QSplitter *splitter = new QSplitter(Qt::Vertical);
+    splitter->setChildrenCollapsible(false);
+
+    this->graph_node_widget = new GraphNodeWidget(gno->get_shared());
+
+    // skip the 3D viewer (OpenGL) in headless CLI modes (e.g. --snapshot).
+    if (!HSD_CTX.headless)
+    {
+      this->viewer = new Viewer3D(this->graph_node_widget);
+      this->viewer->setMinimumHeight(32);
+      splitter->addWidget(this->viewer);
+    }
+
+    splitter->addWidget(this->graph_node_widget);
+    graph_layout->addWidget(splitter);
+  }
+
+  {
+    auto *graph_toolbar = new GraphToolbar(this->graph_node_widget);
+    graph_layout->addWidget(graph_toolbar);
+  }
+
+  // settings panel (created after graph_node_widget, which it takes).
+  this->node_settings_widget = new NodeSettingsWidget(this->graph_node_widget);
+  {
+    std::string color = HSD_CTX.app_settings.colors.border.name().toStdString();
+    set_style(this->node_settings_widget,
+              std::format("border-left: 1px solid {};", color));
+    this->node_settings_widget->setVisible(
+        HSD_CTX.app_settings.node_editor.show_node_settings_pan);
+  }
+
+  // horizontal splitter: [ graph area | settings ] — user-resizable.
+  QSplitter *h_splitter = new QSplitter(Qt::Horizontal);
+  h_splitter->setChildrenCollapsible(false);
+  h_splitter->addWidget(graph_container);
+  h_splitter->addWidget(this->node_settings_widget);
+  h_splitter->setStretchFactor(0, 1); // graph area absorbs window resizing
+  h_splitter->setStretchFactor(1, 0); // settings keeps its width
+  h_splitter->setSizes({900, 400});   // default: graph large, settings ~400px
+
+  layout->addWidget(h_splitter, 0, row_offset, 2, 1);
+```
+Ensure `#include <QVBoxLayout>` is present at the top of the file (`<QSplitter>` is already included at line 5); add it if missing. Confirm `graph_node_widget`, `viewer`, `node_settings_widget` are members (they are — assigned via `this->`), and that nothing after `setup_layout`'s replaced region referenced the old local `graph_toolbar` (it was a block-local; safe).
+
+- [ ] **Step 4: Build Hesiod (controller, detached)**
+
+```bash
+nix develop ~/quixote#cpp-qt-desktop -c bash -c 'cd /home/barrulus/dev/Hesiod && cmake --build build -j4 --target hesiod 2>&1 | tail -20; echo EXIT=${PIPESTATUS[0]}'
+```
+Expected: `Linking CXX executable ... bin/hesiod`, `EXIT=0`. (Run in background per env notes.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/barrulus/dev/Hesiod
+git add Hesiod/src/gui/widgets/graph_editor_widget.cpp Hesiod/src/gui/widgets/node_settings_widget.cpp
+git commit -m "feat(gui): resizable node-settings panel via horizontal splitter (drop 360px cap)"
+```
+
+- [ ] **Step 6: GUI verification (user-driven)**
+
+Launch `build/bin/hesiod`. Confirm:
+1. The settings panel opens at a comfortable width (~400px); add a `Noise` node and select it — the **Spatial Frequency (`kw`) linked sliders are not clipped** at the default width.
+2. **Drag the splitter handle** between the graph and the settings panel → the panel **widens/narrows** smoothly; the graph area takes the remaining space.
+3. Drag the panel **narrower** than its content → a **horizontal scrollbar** appears in the settings area (no clipping).
+4. The **viewer/graph vertical splitter** still works; the **node library** pane is unaffected; nodes still add/select/compute; no crash.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** §4.1 horizontal splitter (Step 3), §4.2 min-only cap (Step 1), §4.3 scroll AsNeeded (Step 2), §7 testing (Steps 4-6). §2 out-of-scope (Meta widget sizing, persistence) correctly excluded.
+- **Placeholder scan:** none — concrete code and the `{900, 400}` default sizes are explicit.
+- **Type consistency:** single task; `graph_container`/`h_splitter` are local; `graph_node_widget`/`viewer`/`node_settings_widget` remain the existing members, created in the same order (graph_node_widget before node_settings_widget) as today.
+- **External-API confirmations flagged:** the `<QVBoxLayout>` include and that no code after the replaced region uses the old block-local `graph_toolbar` are directed to confirm against the source.
+- **One task, by design:** the cap removal (Steps 1-2) and the splitter (Step 3) are coupled — removing the cap without the splitter leaves the panel width ungoverned — so they ship and verify together.

--- a/docs/meta-migration/phase-ab-poc-ledger.md
+++ b/docs/meta-migration/phase-ab-poc-ledger.md
@@ -1,0 +1,79 @@
+# SDD Progress — Meta Migration Phase A + B
+
+Plan: docs/superpowers/plans/2026-07-09-meta-migration-phase-ab.md
+Branch: feature/meta-migration
+Branch base SHA: 34454aa3
+
+Verification model (env-adapted, per repo precedent): subagents write + inspect-verify
+per task; controller runs consolidated build via `nix develop /home/barrulus/quixote#cpp-qt-desktop`
+at phase boundaries; headless `hesiod --inventory` for runtime checks; GUI visual smoke is user-driven.
+
+Working tree caveat: external/{GNode,GNodeGUI,HighMap} show as M (user's checkout deltas) +
+untracked files — NEVER stage them. Each task stages only its own named files.
+
+## Tasks
+- [x] A1: Add Meta as submodule (frozen pin)
+- [x] A2: Wire Meta into CMake build + prove it links
+- [x] B1: Opt-in meta::ContainerGroup on BaseNode
+- [x] B2: Author Noise node params on Meta
+- [x] B3: Render Noise panel via meta_qt
+- [x] B4: Serialize meta-backed Noise (build green; round-trip pending user) (both shapes, decide)
+- [x] B5: Facade-vs-codemod decision doc
+
+## Ledger
+(base 34454aa3)
+Task A1: complete (commit 34454aa3..93e42ed3, Meta pinned e71e798; staged only .gitmodules+external/Meta, review clean)
+Task A2: complete (commit 93e42ed3..d1a010f2, review clean).
+  PHASE A GATE PASSED: meta (12/12 -> libmeta.a) + meta_qt (22/22 -> libmeta_qt.a) compile in
+  Hesiod's Qt6 toolchain; hesiod binary LINKS with meta+meta_qt (384/384, build/bin/hesiod).
+  CAVEAT: headless `--inventory` run hit a Qt runtime skew (libQt6Qml Qt_6_PRIVATE_API undefined
+  symbol = qtdeclarative 6.11.0 vs built-against Qt6 mismatch). ENVIRONMENTAL, not from Meta
+  (our libs don't link QML). Runtime/GUI verification is user-driven; B3/B4 runtime checks need
+  user's working Qt runtime env.
+Task B1: complete (commit d1a010f2..4cc249c8, review clean; uses_meta/meta_group accessors match contract, legacy attr map untouched)
+Task B2: complete (commit 4cc249c8..d83af78d, review clean; 4 attrs -> meta container w/ ui metadata, post-process kept legacy, compute reads via c.value<T>). BUILD GREEN (hesiod links, meta API compiles).
+Task B3: complete (commit d83af78d..c99576e2, review clean; setup_layout branches on uses_meta -> meta::qt::ContainerGroupWidget, value_changed->recompute wired; setup_connections null-guard pre-existing). BUILD GREEN.
+Task B3: GUI-VERIFIED (user, 6.11.1 rebuild). Meta panel renders: Settings>Main Parameters/Tiling
+  collapsible groups (ui.category), Type=Perlin dropdown, Spatial Frequency X/Y linked+locked
+  (x==y confirmed), Seed, Periodic checkbox; terrain recomputes. FUNCTIONAL PASS.
+  FINDING (logged, deferred per user): Meta slider/LinkedSliders minimumWidth exceeds Hesiod's
+  hard-capped 360px settings panel (node_settings_widget.cpp:28-29 "TODO fix this",
+  ScrollBarAlwaysOff) -> widest widget (kw paired sliders) forces container wide, all inputs clip.
+  Proper fix = Meta widget sizing / panel cap, belongs to Meta-editing phase. Empty toolbar
+  buttons = qtsvg launch-env (SVG icons), not Meta.
+ENV NOTE: nixpkgs bumped Qt 6.11.0->6.11.1 overnight; stale build/ (CMakeCache 6.11.0 RUNPATH)
+  caused Qt_6_PRIVATE_API symbol skew. FIX: rm -rf build + fresh configure under devshell ->
+  coherent 6.11.1 binary. Full rebuilds must be capped (-j4) + detached (unbounded -j OOMs, killed foot).
+Task B4: code-complete, BUILD GREEN (commit b2659356; base_node.cpp json_to/json_from add native
+  _meta shape for uses_meta nodes + fail-loud else-guard when _meta absent). DECISION: native shape
+  chosen over adapter -- adapter can't reproduce legacy semantic .hsd type tags (Enum/Seed/Wavenumber)
+  from Meta's plain value-types (int/vec2/bool) without a bespoke per-attr semantic map. Full-migration
+  implication (Python hsd toolkit + site/examples/*.hsd assume legacy shape) = documented finding.
+  ROUND-TRIP VERIFICATION: pending user GUI save/reload + controller .hsd inspection.
+Task B5: complete (controller doc task). Decisions recorded in design spec §11: serialization=native
+  _meta; facade over codemod (5-8 lines/attr direct vs 1-line legacy -> facade shim maps legacy
+  add_attr type -> meta add<T>+metadata); widget-width + env notes captured.
+
+B4 ROUND-TRIP WRITE VERIFIED (user save /output/meta-noise-test.hsd): _meta block present at
+  graph_manager/graph_nodes/graph/nodes[4]; saved values match user input exactly
+  (kw={4,4}, noise_type=6, periodic=true, seed=42). Read side = user reload confirm (pending).
+  FINDINGS: native _meta is heavily BLOATED (serializes full metadata tree incl. nested
+  snapshot_manager, not just values) + a stray ui.state entry -> future refinement (serialize
+  values only). Logged, not blocking.
+
+BUGFIX (found in GUI verification, commit follows fix-build): fresh Noise node rendered FLAT until
+  a value change. Root cause = B2 defaulted noise_type to raw int 0, not a valid hmap::NoiseType;
+  GraphNode::add_node DOES compute on add (line 53 node->compute()) but with 0 -> flat. Re-selecting
+  the shown combo item emits no change (Qt) so flat persisted. FIX: default = (int)NoiseType::SIMPLEX2
+  (matches displayed 'OpenSimplex2', valid, consistent under either combo-sync behavior).
+
+## FINAL WHOLE-BRANCH REVIEW (opus): 1 crash found+fixed, rest accepted
+- F1 CONFIRMED crash (HIGH): meta branch nulls attributes_widget but create_toolbar's 5 state/preset
+  buttons deref it unconditionally (add_toolbar defaults true) -> click crashes Noise node.
+  FIXED commit (finding1): guard each lambda `if (this->attributes_widget)`.
+- F2 low: kw max capped 64 vs legacy FLT_MAX. ACCEPTED (sane slider bound; FLT_MAX impractical).
+- F3 by-design: pre-branch .hsd Noise nodes load to defaults WITH loud log (= intended fail-loud;
+  documented full-migration concern, not a bug). Round-trip within branch sound.
+- F4 latent: const meta_group() unguarded but safe behind sole gated caller (json_to). Left as-is.
+- Verified clean: Meta API usage vs frozen headers, legacy path intact, commit hygiene (only 8+2 fix
+  files; dirty external/{GNode,GNodeGUI,HighMap} + untracked NOT committed).

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -23,6 +23,14 @@ add_subdirectory(HighMap)
 set(ATTRIBUTES_ENABLE_TESTS OFF)
 add_subdirectory(Attributes)
 
+# Meta (transitional: built alongside Attributes)
+set(META_ENABLE_TESTS OFF)
+set(META_ENABLE_GLM_TYPES ON)
+set(META_ENABLE_COLOR_GRADIENT_TYPES ON)
+set(META_ENABLE_QT_UI ON)
+set(META_ENABLE_FTXUI_UI OFF)
+add_subdirectory(Meta)
+
 # QTerrainRenderer
 add_subdirectory(QTerrainRenderer)
 


### PR DESCRIPTION
## Overview

First phase of migrating Hesiod's node-attribute + widget layer onto Otto's new
[`otto-link/Meta`](https://github.com/otto-link/Meta) framework (the successor to
`Attributes` + `QSliderX`). Meta is added as a submodule and built **alongside** the existing
`attributes` library, so migration is incremental and legacy nodes are untouched. Three nodes are
fully migrated as vertical slices, and the new Meta-side capabilities they needed are built and
wired.

## What's included

**Build / infrastructure**
- `external/Meta` added as a submodule; `meta` + `meta_qt` compile and link in Hesiod's toolchain,
  built next to `attributes` during the transition.
- `BaseNode` gains an **opt-in** `meta::ContainerGroup` (`uses_meta()` / `meta_group()`) beside the
  legacy `attr` map — a node moves to Meta storage individually; nothing else changes.
- Native `_meta` serialization in `BaseNode::json_to/json_from` with a fail-loud guard.

**Migrated nodes (3)**
- **Noise** — params on a Meta container (enum dropdown, X/Y-locked wavenumber, seed, bool),
  `ui.category` grouping, auto-rendered panel.
- **Saturate** — range control with a live input **histogram** behind the handles.
- **Cloud** — point-cloud editor with a live **heightmap thumbnail** behind the points.

**New Meta-side capabilities (on the coupled Meta branch, see below)**
- `ui.data_provider` — a general, Qt-free host-callback mechanism feeding runtime-computed data to
  a widget; one hook drives both the RangeBar histogram (series) and the PointsCanvas background
  (image). Plus `ui.tooltip`.
- Panel refresh reworked to **sync widgets from the model on recompute instead of rebuilding**,
  enabling **live preview while dragging** without destroying the widget or re-running providers
  mid-drag.

**GUI**
- The node-settings panel is now a **resizable splitter pane** (no more hard 360px cap), with a
  horizontal-scroll fallback.

## Coupled Meta changes (important)

The `external/Meta` submodule pin here points at **`otto-link/Meta` branch `feature/meta-migration`**
(the `ui.data_provider`/`ui.tooltip` mechanism, `MetaWidget::is_editing`, and a const-`try_cast`
fix). That branch must be available/merged for this to build — recommended cutover order is **Meta
first, then bump this pin**. It is pushed and ready for review on the Meta repo.

## Design docs

Full specs, plans, and execution notes are under `docs/meta-migration/` (assessment, the 7-gap
analysis + resolutions, and per-feature design/plan docs).

## Testing

Built via the project's Nix devshell (`meta`/`meta_qt`/`hesiod` all link green); each feature was
GUI-verified (histogram + drag, cloud thumbnail, live preview, resizable panel). Legacy (non-migrated)
nodes are unaffected — they keep the `attr`/`AttributesWidget` path.

## Follow-ups (not in this PR)

- The remaining ~197 nodes — planned as a compatibility facade over the storage swap.
- `_meta` serialization slimming (values-only) — pending an Otto decision on the Meta format
  (otto-link/Meta#16).
- Meta paired-slider widget sizing (narrow-panel fit) — an Otto-side widget question.
- Optional: collapsible node-library pane.
