### PR TITLE
Resizable node-settings panel (drop hard 360px cap)

### DIFF
--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -137,16 +137,22 @@ void GraphEditorWidget::setup_layout()
     row_offset++;
   }
 
-  // left pan with splitter
+  // graph area: viewer/graph vertical splitter + toolbar, wrapped so it can be
+  // one pane of the horizontal splitter below.
+  QWidget     *graph_container = new QWidget();
+  QVBoxLayout *graph_layout = new QVBoxLayout(graph_container);
+  graph_layout->setContentsMargins(0, 0, 0, 0);
+  graph_layout->setSpacing(0);
+
   {
     QSplitter *splitter = new QSplitter(Qt::Vertical);
     splitter->setChildrenCollapsible(false);
 
     this->graph_node_widget = new GraphNodeWidget(gno->get_shared());
+    this->graph_node_widget->setMinimumWidth(50); // let the graph pane shrink so the
+                                                  // settings pane can be dragged wider
 
-    // skip the 3D viewer (OpenGL) in headless CLI modes (e.g. --snapshot): it
-    // would receive paint events and crash without a real GUI window context.
-    // get_viewer() stays null and every caller already null-guards it.
+    // skip the 3D viewer (OpenGL) in headless CLI modes (e.g. --snapshot).
     if (!HSD_CTX.headless)
     {
       this->viewer = new Viewer3D(this->graph_node_widget);
@@ -155,29 +161,38 @@ void GraphEditorWidget::setup_layout()
     }
 
     splitter->addWidget(this->graph_node_widget);
-
-    layout->addWidget(splitter, 0, row_offset);
+    graph_layout->addWidget(splitter);
   }
 
-  // right pan
   {
-    this->node_settings_widget = new NodeSettingsWidget(this->graph_node_widget);
+    auto *graph_toolbar = new GraphToolbar(this->graph_node_widget);
+    graph_layout->addWidget(graph_toolbar);
+  }
 
+  // settings panel (created after graph_node_widget, which it takes).
+  this->node_settings_widget = new NodeSettingsWidget(this->graph_node_widget);
+  {
     std::string color = HSD_CTX.app_settings.colors.border.name().toStdString();
     set_style(this->node_settings_widget,
               std::format("border-left: 1px solid {};", color));
-
-    layout->addWidget(this->node_settings_widget, 0, row_offset + 1, 2, 1);
-
     this->node_settings_widget->setVisible(
         HSD_CTX.app_settings.node_editor.show_node_settings_pan);
   }
 
-  // bottom toolbar
-  {
-    auto *graph_toolbar = new GraphToolbar(this->graph_node_widget);
-    layout->addWidget(graph_toolbar, 1, row_offset);
-  }
+  // horizontal splitter: [ graph area | settings ] — user-resizable.
+  QSplitter *h_splitter = new QSplitter(Qt::Horizontal);
+  h_splitter->setChildrenCollapsible(false);
+  h_splitter->addWidget(graph_container);
+  h_splitter->addWidget(this->node_settings_widget);
+  h_splitter->setStretchFactor(0, 1); // graph area absorbs window resizing
+  h_splitter->setStretchFactor(1, 0); // settings keeps its width
+  h_splitter->setSizes({650, 500});   // default: settings opens wide enough for paired sliders
+
+  layout->addWidget(h_splitter, 0, row_offset, 2, 1);
+
+  // Give the graph/settings splitter column the window's spare width so it always
+  // has room to drag (otherwise the split only widens when the whole window grows).
+  layout->setColumnStretch(row_offset, 1);
 
   // --- Connection(s)
 

--- a/Hesiod/src/gui/widgets/node_settings_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_settings_widget.cpp
@@ -25,8 +25,7 @@ NodeSettingsWidget::NodeSettingsWidget(QPointer<GraphNodeWidget> p_graph_node_wi
   if (!this->p_graph_node_widget)
     return;
 
-  this->setMinimumWidth(360); // TODO fix this
-  this->setMaximumWidth(360);
+  this->setMinimumWidth(240); // low floor so the pane is freely narrowable; wide content scrolls
 
   this->setup_layout();
   this->setup_connections();
@@ -72,7 +71,7 @@ void NodeSettingsWidget::setup_layout()
     this->attr_layout->setSpacing(2);
 
     auto *scroll = new QScrollArea();
-    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     scroll->setWidget(container);
     scroll->setWidgetResizable(true);
     scroll->setFrameShape(QFrame::NoFrame);


### PR DESCRIPTION
## What

Makes the node-settings panel **user-resizable** and stops it clipping wide widgets, replacing the
hard-coded 360px cap (`node_settings_widget.cpp` `// TODO fix this`).

## Why

The settings panel was fixed at `setMinimumWidth(360); setMaximumWidth(360);` with horizontal
scroll off, so any widget wider than 360px was clipped and the panel couldn't be resized.

## How (2 files, GUI-only)

- **`graph_editor_widget.cpp`** — wrap the graph area (viewer/graph vertical splitter + toolbar)
  and the settings panel in a horizontal `QSplitter` so the divider is draggable; give the splitter
  column the grid stretch and a sensible default (`setSizes({650, 500})`); give the graph canvas a
  small minimum width so it can yield space to the settings pane.
- **`node_settings_widget.cpp`** — drop `min==max==360` to a low `setMinimumWidth(240)` (no max) so
  the pane can be freely narrowed, and set the scroll area to `ScrollBarAsNeeded` so wide content
  scrolls instead of clipping.

## Result

The settings panel opens at a comfortable width, is drag-resizable at any window size, and never
clips (scrolls as a last resort).

## Testing

Builds green in the project Nix devshell; GUI-verified — panel opens wide, divider drags freely at
half-screen, contents scroll when narrowed, graph/viewer and node library unaffected.
