### PR TITLE
fix(docs): repoint the "node reference" cross-links at a page that exists

### DIFF
--- a/docs/core_concepts/heightmaps.md
+++ b/docs/core_concepts/heightmaps.md
@@ -31,6 +31,6 @@ that consumes it.
 
 ## See also
 
-- [Node reference](../node_reference/) — every node's input/output heightmap ports.
+- [Node reference](../node_reference/categories.md) — every node's input/output heightmap ports.
 - [Tiling & overlap](tiling-overlap.md) — how a heightmap is computed in pieces.
 - [Coordinate system](../user_manual/coordinate_system/index.md) — the normalized domain.

--- a/docs/core_concepts/index.md
+++ b/docs/core_concepts/index.md
@@ -1,7 +1,7 @@
 # Core Concepts
 
 Hesiod builds terrain by connecting **nodes** into a **graph**. Before diving into
-the [node reference](../node_reference/) or the [user manual](../user_manual/index.md),
+the [node reference](../node_reference/categories.md) or the [user manual](../user_manual/index.md),
 it helps to know a handful of ideas that everything else is built on. Each page
 below is short and links down to the deeper documentation when you want detail.
 

--- a/docs/core_concepts/masks-selectors.md
+++ b/docs/core_concepts/masks-selectors.md
@@ -32,5 +32,5 @@ union (per-cell maximum), or exclusion (the difference) — so you can build up
 
 ## See also
 
-- [Node reference → selector nodes](../node_reference/) — the full `Select…` family.
+- [Node reference → selector nodes](../node_reference/categories.md) — the full `Select…` family.
 - [Heightmaps & virtual arrays](heightmaps.md) — a mask *is* a heightmap.

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -132,7 +132,7 @@ coloured version as a quick visual reference.
 
 - **[Core Concepts](../core_concepts/index.md)** — the ideas behind what you just did
   (heightmaps, masks, tiling, broadcast).
-- **[Node reference](../node_reference/)** — every node, with its input/output ports
+- **[Node reference](../node_reference/categories.md)** — every node, with its input/output ports
   and parameters.
 - **[Building a "patch of graphs"](../user_manual/patch-of-graphs.md)** — the advanced
   worldbuilding track: stitching several graphs into one large world.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,7 +1,7 @@
 # Guides
 
 Task-oriented walkthroughs that sit between the [Core Concepts](../core_concepts/index.md)
-vocabulary and the exhaustive [Node Reference](../node_reference/). Each guide
+vocabulary and the exhaustive [Node Reference](../node_reference/categories.md). Each guide
 answers a specific "how do I…" and points you at the right nodes.
 
 - [Erosion — thermal vs hydraulic](erosion.md) — carve and smooth terrain.


### PR DESCRIPTION
Five docs pages linked to a bare directory path `../node_reference/`, which does not resolve to a real URL.

## The bug

mkdocs only rewrites a relative link when the target is a `.md` file; a bare directory is emitted verbatim. Under `use_directory_urls` (the default) the page itself occupies a URL level, so `../` climbs one level too few:

| Page | Bad link resolved to |
| :--- | :--- |
| `core_concepts/masks-selectors.md` | `/core_concepts/node_reference/` — 404 |
| `core_concepts/heightmaps.md` | `/core_concepts/node_reference/` — 404 |
| `core_concepts/index.md` | `/node_reference/` — 404 (section has no landing page) |
| `getting_started/index.md` | `/node_reference/` — 404 |
| `guides/index.md` | `/node_reference/` — 404 |

Reported by a reader on the masks-selectors page who followed the "node reference → selector nodes" link and landed on an empty page.

## The fix

Point all five at `../node_reference/categories.md`, the real section index. mkdocs then computes the depth itself and emits `../../node_reference/categories/`. The sibling link in `tiling-overlap.md` already used this `.md`-target form and was unaffected — this just brings the other five into line.

Five files, one line each. Verified with `mkdocs build --strict` (no broken links).