### PR TITLE
Stagger saved-viewport creation across event-loop turns on load

### DIFF
--- a/Hesiod/include/hesiod/gui/widgets/graph_node_widget.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/graph_node_widget.hpp
@@ -124,6 +124,9 @@ private:
   void backup_selected_ids();
   void reselect_backup_ids();
 
+  void restore_viewers_sequentially(std::vector<nlohmann::json> viewer_jsons,
+                                    std::size_t                 index);
+
   // --- Members ---
   std::weak_ptr<GraphNode>       p_graph_node; // own by GraphManager
   std::vector<QPointer<QWidget>> data_viewers;

--- a/Hesiod/src/gui/widgets/graph_node_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_node_widget.cpp
@@ -335,30 +335,22 @@ void GraphNodeWidget::json_from(nlohmann::json const &json)
   this->set_block_graph_model_updates(false);
 
   // viewers (skipped in headless CLI modes, e.g. --snapshot: no 3D viewer is
-  // created there, so there is nothing to restore state into)
+  // created there, so there is nothing to restore state into). Creation is
+  // staggered, one viewport per event-loop turn: creating several GL windows
+  // synchronously during load crashes on some Windows drivers (issue #537)
   if (!HSD_CTX.headless && json.contains("viewers") && json["viewers"].is_array())
   {
-    for (const auto &viewer_json : json["viewers"])
-    {
-      ViewerType viewer_type = viewer_json["viewer_type"].get<ViewerType>();
+    std::vector<nlohmann::json> viewer_jsons(json["viewers"].begin(),
+                                             json["viewers"].end());
 
-      Logger::log()->trace("GraphNodeWidget::json_from: viewer_type: {}",
-                           viewer_type_as_string.at(viewer_type));
-
-      // TODO add viewer-type specific handling
-      this->on_viewport_request();
-
-      if (auto *p_viewer = dynamic_cast<Viewer3D *>(this->data_viewers.back().get()))
-      {
-        // defer to let OpenGL context settle
-        QTimer::singleShot(0,
-                           [p_viewer, viewer_json]()
-                           { p_viewer->json_from(viewer_json); });
-      }
-      else
-        Logger::log()->error(
-            "GraphNodeWidget::json_from: could not retrieve viewer reference");
-    }
+    QTimer::singleShot(0,
+                       this,
+                       [this, viewer_jsons = std::move(viewer_jsons)]() mutable
+                       {
+                         this->restore_viewers_sequentially(
+                             std::move(viewer_jsons),
+                             0);
+                       });
   }
 
   // defer
@@ -1274,6 +1266,58 @@ void GraphNodeWidget::on_viewport_request()
 
   if (selected_ids.size())
     p_viewer->on_node_selected(selected_ids.back());
+}
+
+void GraphNodeWidget::restore_viewers_sequentially(
+    std::vector<nlohmann::json> viewer_jsons,
+    std::size_t                 index)
+{
+  if (index >= viewer_jsons.size())
+    return;
+
+  ViewerType viewer_type = viewer_jsons[index]["viewer_type"].get<ViewerType>();
+
+  Logger::log()->trace(
+      "GraphNodeWidget::restore_viewers_sequentially: {}/{}, viewer_type: {}",
+      index + 1,
+      viewer_jsons.size(),
+      viewer_type_as_string.at(viewer_type));
+
+  // TODO add viewer-type specific handling
+  const std::size_t count_before = this->data_viewers.size();
+  this->on_viewport_request();
+
+  if (this->data_viewers.size() == count_before)
+  {
+    Logger::log()->error(
+        "GraphNodeWidget::restore_viewers_sequentially: viewport was not "
+        "created, aborting viewer state restore");
+    return;
+  }
+
+  QPointer<Viewer3D> p_viewer(
+      dynamic_cast<Viewer3D *>(this->data_viewers.back().get()));
+
+  if (!p_viewer)
+  {
+    Logger::log()->error(
+        "GraphNodeWidget::restore_viewers_sequentially: could not retrieve "
+        "viewer reference");
+    return;
+  }
+
+  // next event-loop turn: the new window's GL context has settled; restore
+  // its state, then create the next saved viewport (if any)
+  QTimer::singleShot(
+      0,
+      this,
+      [this, viewer_jsons = std::move(viewer_jsons), index, p_viewer]() mutable
+      {
+        if (p_viewer)
+          p_viewer->json_from(viewer_jsons[index]);
+
+        this->restore_viewers_sequentially(std::move(viewer_jsons), index + 1);
+      });
 }
 
 void GraphNodeWidget::reselect_backup_ids()


### PR DESCRIPTION
## Summary

Loading a .hsd with 2+ saved viewports created every Viewer3D synchronously in a loop inside `GraphNodeWidget::json_from` — two full GL window initializations back-to-back in the same event-loop turn, during load, interleaved with the old project's viewer teardown. That crashes on some Windows drivers (#537); the only creation path known crash-free is a user click, which always gets its own turn.

Saved viewers are now restored through a self-scheduling chain: create one viewport per event-loop turn, restore its state the following turn, then create the next. Also removes a latent use-after-free: the old deferred state-restore captured a raw viewer pointer in a `QTimer::singleShot` with no context object; the chain uses `QPointer` + `this` as context, so pending steps die with the widget.

## Companion PR
otto-link/QTerrainRenderer#22 fixes the renderer-side crashes found while verifying this (one reproduced on unmodified dev by closing 1 of 2 viewports; one root-caused from a core dump to `~RenderWidget` deleting a surviving viewer's GL objects — that mechanism is also a strong candidate for the actual #537 Windows crash, since load destroys the old viewers amid new viewport creation). The two PRs are independent; no submodule pin change here (this PR touches exactly two files). Testing both together is recommended.

## Verification
- Linux (Wayland/niri, Mesa, Qt 6.11), with the companion branch in the submodule: 2- and 3-viewport loads restore correctly (staggered); save round-trip preserves the viewers array; immediate double-load and quit-mid-restore safe; repeated load/teardown churn and close/reopen cycles clean; headless `--batch` unaffected (the headless skip is preserved).
- Windows: pending — Otto offered testing, and a Win 11 / Intel CPU / AMD GPU machine is lined up with the release-build repro + minidump protocol. Will report results here.

## Known edges (accepted)
- A save fired within the few event-loop turns before the chain completes would serialize fewer viewports than were loaded (window is milliseconds).
- A malformed `viewer_type` in the file throws as before, but now from a timer callback rather than the load call site.
- Two pre-existing context-less `singleShot`s remain in this file (post-restore update at ~line 357, `reselect_backup_ids`) — same latent pattern this PR removes for viewers; left for a follow-up.

Fixes #537