### PR TITLE
fix: don't fire the deferred viewer restore into a freed viewer

### DIFF
--- a/Hesiod/src/gui/widgets/graph_node_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_node_widget.cpp
@@ -7,6 +7,7 @@
 #include <QFileDialog>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPointer>
 #include <QScreen>
 #include <QTimer>
 #include <QToolButton>
@@ -350,10 +351,17 @@ void GraphNodeWidget::json_from(nlohmann::json const &json)
 
       if (auto *p_viewer = dynamic_cast<Viewer3D *>(this->data_viewers.back().get()))
       {
-        // defer to let OpenGL context settle
+        // defer to let OpenGL context settle. The viewer can be destroyed
+        // before the timer fires - closing the viewport, or another load
+        // replacing the viewers - so hold it through a QPointer and give the
+        // timer a context object, otherwise this fires into freed memory
         QTimer::singleShot(0,
-                           [p_viewer, viewer_json]()
-                           { p_viewer->json_from(viewer_json); });
+                           this,
+                           [viewer = QPointer<Viewer3D>(p_viewer), viewer_json]()
+                           {
+                             if (viewer)
+                               viewer->json_from(viewer_json);
+                           });
       }
       else
         Logger::log()->error(


### PR DESCRIPTION
## Summary

`GraphNodeWidget::json_from` defers each saved viewer's state restore:

```cpp
QTimer::singleShot(0, [p_viewer, viewer_json]() { p_viewer->json_from(viewer_json); });
```

A raw `Viewer3D*` capture with no context object. Nothing keeps the viewer alive until the timer fires, so a viewport closed — or replaced by another project load — within that event-loop turn leaves the lambda calling `json_from()` on freed memory.

Fix: hold the viewer through a `QPointer` and give the timer `this` as its context object, so the callback is dropped if the widget goes away and skipped if only the viewer does.

## Notes

Latent — I haven't managed to trigger it deliberately, since it needs a viewport destroyed inside the one event-loop turn between load and restore. Found while working #537, but unrelated to it: that turned out to be an ImGui-context ordering bug in QTerrainRenderer (otto-link/QTerrainRenderer#23), nothing to do with the load path.

This is the one piece worth keeping from the closed #645.

## Verification

Windows 11 / Qt 6.10.0 / MSVC: loading 2- and 3-viewport projects restores every viewer as before (4 restores, no `could not retrieve viewer reference` errors), clean shutdown.