### PR TITLE
Collapsible node library panel with View-menu toggle

### DIFF
--- a/Hesiod/include/hesiod/app/hesiod_application.hpp
+++ b/Hesiod/include/hesiod/app/hesiod_application.hpp
@@ -6,6 +6,7 @@
 #include <QApplication>
 #include <QCoreApplication>
 #include <QMenu>
+#include <QPointer>
 #include <QProgressBar>
 #include <QStandardPaths>
 
@@ -63,6 +64,7 @@ private slots:
   void on_new();
   void on_online_help();
   void on_project_settings();
+  void on_toggle_node_library_pan();
   void on_quit();
   void on_open_recent(const std::string &fname);
   void on_save();
@@ -87,6 +89,7 @@ private:
   AppSettingsWindow         *app_settings_window;   // owned by MainWindow
 
   QMenu *recent_files_menu = nullptr; // owned by the menu bar
+  QPointer<QAction> show_node_library_pan_action; // owned by the menu bar
 
   BlenderStreamer blender_streamer;
 

--- a/Hesiod/include/hesiod/app/hesiod_application.hpp
+++ b/Hesiod/include/hesiod/app/hesiod_application.hpp
@@ -53,11 +53,12 @@ public:
   bool confirm_discard_unsaved_changes(const QString &action_title);
 
   // --- Context
-  QApplication     &get_qapp();
+  QApplication &get_qapp();
+
+  BlenderStreamer  &get_blender_streamer();
   AppContext       &get_context();
   const AppContext &get_context() const;
   ProjectUI        *get_project_ui_ref();
-  BlenderStreamer  &get_blender_streamer();
 
 private slots:
   // --- User actions
@@ -68,12 +69,12 @@ private slots:
   void on_new();
   void on_online_help();
   void on_project_settings();
-  void on_toggle_node_library_pan();
   void on_quit();
   void on_open_recent(const std::string &fname);
   void on_save();
   void on_save_as();
   void on_save_copy();
+  void on_toggle_node_library_pan();
   void show_about();
   void show_quick_help();
 
@@ -92,7 +93,7 @@ private:
   std::unique_ptr<ProjectUI> project_ui;            // because top-level UI
   AppSettingsWindow         *app_settings_window;   // owned by MainWindow
 
-  QMenu *recent_files_menu = nullptr; // owned by the menu bar
+  QMenu            *recent_files_menu = nullptr;  // owned by the menu bar
   QPointer<QAction> show_node_library_pan_action; // owned by the menu bar
 
   BlenderStreamer blender_streamer;

--- a/Hesiod/include/hesiod/gui/widgets/graph_editor_widget.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/graph_editor_widget.hpp
@@ -6,6 +6,8 @@
 #include "hesiod/gui/widgets/node_library_widget.hpp"
 #include "hesiod/model/nodes/base_node.hpp"
 
+class QToolButton;
+
 namespace hesiod
 {
 
@@ -32,6 +34,10 @@ public:
   GraphNodeWidget    *get_graph_node_widget() const;
   NodeSettingsWidget *get_node_settings_widget() const;
   Viewer3D           *get_viewer() const;
+  void               set_node_library_visible(bool new_state);
+
+signals:
+  void node_library_toggle_requested();
 
 private:
   void setup_connections();
@@ -42,6 +48,7 @@ private:
   NodeSettingsWidget      *node_settings_widget = nullptr;
   NodeLibraryWidget       *node_library_widget = nullptr;
   Viewer3D                *viewer = nullptr;
+  QToolButton             *node_library_toggle_button = nullptr;
 };
 
 } // namespace hesiod

--- a/Hesiod/include/hesiod/gui/widgets/graph_editor_widget.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/graph_editor_widget.hpp
@@ -34,7 +34,7 @@ public:
   GraphNodeWidget    *get_graph_node_widget() const;
   NodeSettingsWidget *get_node_settings_widget() const;
   Viewer3D           *get_viewer() const;
-  void               set_node_library_visible(bool new_state);
+  void                set_node_library_visible(bool new_state);
 
 signals:
   void node_library_toggle_requested();

--- a/Hesiod/include/hesiod/gui/widgets/graph_tabs_widget.hpp
+++ b/Hesiod/include/hesiod/gui/widgets/graph_tabs_widget.hpp
@@ -30,6 +30,7 @@ public:
   void clear();
   void set_show_node_settings_widget(bool new_state);
   void set_show_viewer(bool new_state);
+  void set_show_node_library_pan(bool new_state);
 
   // --- Serialization ---
   void           json_from(nlohmann::json const &json);
@@ -45,6 +46,7 @@ signals:
   void has_changed();
   void new_node_created(const std::string &graph_id, const std::string &id);
   void node_deleted(const std::string &graph_id, const std::string &id);
+  void node_library_toggle_requested();
 
   // --- Graph
   void update_started();

--- a/Hesiod/src/app/hesiod_application.cpp
+++ b/Hesiod/src/app/hesiod_application.cpp
@@ -303,6 +303,11 @@ void HesiodApplication::load_project_model_and_ui(const std::string &fname,
                 &GraphTabsWidget::has_changed,
                 [this]() { this->context.project_model->on_has_changed(); });
 
+  this->connect(this->project_ui->get_graph_tabs_widget_ref(),
+                &GraphTabsWidget::node_library_toggle_requested,
+                this,
+                &HesiodApplication::on_toggle_node_library_pan);
+
   // Project -> HesiodApplication
   this->context.project_model->project_name_changed = [this]()
   { this->on_project_name_changed(); };
@@ -575,6 +580,18 @@ void HesiodApplication::on_project_settings()
 {
   auto *dialog = new ProjectSettingsDialog(this->context.project_model.get());
   dialog->exec();
+}
+
+void HesiodApplication::on_toggle_node_library_pan()
+{
+  bool new_state = !this->context.app_settings.node_editor.show_node_library_pan;
+  this->context.app_settings.node_editor.show_node_library_pan = new_state;
+
+  if (this->show_node_library_pan_action)
+    this->show_node_library_pan_action->setChecked(new_state);
+
+  if (this->project_ui)
+    this->project_ui->get_graph_tabs_widget_ref()->set_show_node_library_pan(new_state);
 }
 
 void HesiodApplication::on_quit()
@@ -874,12 +891,20 @@ void HesiodApplication::setup_menu_bar()
     view_menu->addAction(show_viewer_action);
   }
 
-  auto *show_node_settings_pan_action = new QAction("Show Node Settings Pan", this);
+  auto *show_node_settings_pan_action = new QAction("Show Node Settings Panel", this);
   show_node_settings_pan_action->setCheckable(true);
   {
     bool state = this->context.app_settings.node_editor.show_node_settings_pan;
     show_node_settings_pan_action->setChecked(state);
     view_menu->addAction(show_node_settings_pan_action);
+  }
+
+  this->show_node_library_pan_action = new QAction("Show Node Library Panel", this);
+  this->show_node_library_pan_action->setCheckable(true);
+  {
+    bool state = this->context.app_settings.node_editor.show_node_library_pan;
+    this->show_node_library_pan_action->setChecked(state);
+    view_menu->addAction(this->show_node_library_pan_action);
   }
 
   // --- connections
@@ -951,6 +976,11 @@ void HesiodApplication::setup_menu_bar()
         this->project_ui->get_graph_tabs_widget_ref()->set_show_node_settings_widget(
             new_state);
       });
+
+  this->connect(this->show_node_library_pan_action,
+                &QAction::triggered,
+                this,
+                &HesiodApplication::on_toggle_node_library_pan);
 
   this->connect(
       show_layout_manager,

--- a/Hesiod/src/app/hesiod_application.cpp
+++ b/Hesiod/src/app/hesiod_application.cpp
@@ -607,18 +607,6 @@ void HesiodApplication::on_project_settings()
   dialog->exec();
 }
 
-void HesiodApplication::on_toggle_node_library_pan()
-{
-  bool new_state = !this->context.app_settings.node_editor.show_node_library_pan;
-  this->context.app_settings.node_editor.show_node_library_pan = new_state;
-
-  if (this->show_node_library_pan_action)
-    this->show_node_library_pan_action->setChecked(new_state);
-
-  if (this->project_ui)
-    this->project_ui->get_graph_tabs_widget_ref()->set_show_node_library_pan(new_state);
-}
-
 void HesiodApplication::on_quit()
 {
   Logger::log()->trace("HesiodApplication::on_quit");
@@ -687,6 +675,18 @@ void HesiodApplication::on_save_copy()
     fs::path fname = insert_before_extension(path, "_" + timestamp());
     this->save_project_model_and_ui(fname.string());
   }
+}
+
+void HesiodApplication::on_toggle_node_library_pan()
+{
+  bool new_state = !this->context.app_settings.node_editor.show_node_library_pan;
+  this->context.app_settings.node_editor.show_node_library_pan = new_state;
+
+  if (this->show_node_library_pan_action)
+    this->show_node_library_pan_action->setChecked(new_state);
+
+  if (this->project_ui)
+    this->project_ui->get_graph_tabs_widget_ref()->set_show_node_library_pan(new_state);
 }
 
 void HesiodApplication::save_backup(const std::string &fname)

--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -141,13 +141,19 @@ void GraphEditorWidget::setup_layout()
   // collapsible left pan for the node library: a thin full-height arrow
   // strip (column 0) toggles the library widget (column 1)
   {
-    this->node_library_toggle_button = new QToolButton();
-    this->node_library_toggle_button->setAutoRaise(true);
-    this->node_library_toggle_button->setFixedWidth(16);
-    this->node_library_toggle_button->setSizePolicy(QSizePolicy::Fixed,
-                                                    QSizePolicy::Expanding);
-    this->node_library_toggle_button->setToolTip("Show/hide the node library panel");
-    layout->addWidget(this->node_library_toggle_button, 0, 0, 2, 1);
+    // no strip in headless CLI modes (e.g. --snapshot): it would eat 16px of
+    // frame width in the rendered doc screenshots, which disable the library
+    // pan precisely to get the full frame for the graph
+    if (!HSD_CTX.headless)
+    {
+      this->node_library_toggle_button = new QToolButton();
+      this->node_library_toggle_button->setAutoRaise(true);
+      this->node_library_toggle_button->setFixedWidth(16);
+      this->node_library_toggle_button->setSizePolicy(QSizePolicy::Fixed,
+                                                      QSizePolicy::Expanding);
+      this->node_library_toggle_button->setToolTip("Show/hide the node library panel");
+      layout->addWidget(this->node_library_toggle_button, 0, 0, 2, 1);
+    }
 
     this->node_library_widget = new NodeLibraryWidget();
     layout->addWidget(this->node_library_widget, 0, 1, 2, 1);
@@ -221,10 +227,11 @@ void GraphEditorWidget::setup_layout()
                   this->graph_node_widget,
                   &GraphNodeWidget::on_new_node_request_replace);
 
-    this->connect(this->node_library_toggle_button,
-                  &QToolButton::clicked,
-                  this,
-                  [this]() { Q_EMIT this->node_library_toggle_requested(); });
+    if (this->node_library_toggle_button)
+      this->connect(this->node_library_toggle_button,
+                    &QToolButton::clicked,
+                    this,
+                    [this]() { Q_EMIT this->node_library_toggle_requested(); });
   }
 }
 

--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -3,6 +3,7 @@
  * this software. */
 #include <QGridLayout>
 #include <QSplitter>
+#include <QToolButton>
 #include <QTimer>
 
 #include "hesiod/app/hesiod_application.hpp"
@@ -44,6 +45,17 @@ NodeSettingsWidget *GraphEditorWidget::get_node_settings_widget() const
 }
 
 Viewer3D *GraphEditorWidget::get_viewer() const { return this->viewer; }
+
+void GraphEditorWidget::set_node_library_visible(bool new_state)
+{
+  if (this->node_library_widget)
+    this->node_library_widget->setVisible(new_state);
+
+  // arrow points at the panel's collapse direction
+  if (this->node_library_toggle_button)
+    this->node_library_toggle_button->setArrowType(new_state ? Qt::LeftArrow
+                                                             : Qt::RightArrow);
+}
 
 void GraphEditorWidget::json_from(nlohmann::json const &json)
 {
@@ -126,15 +138,22 @@ void GraphEditorWidget::setup_layout()
   layout->setSpacing(0);
   this->setLayout(layout);
 
-  // optional left pan for node library
-  bool show_lib = HSD_CTX.app_settings.node_editor.show_node_library_pan;
-  int  row_offset = 0;
-
-  if (show_lib)
+  // collapsible left pan for the node library: a thin full-height arrow
+  // strip (column 0) toggles the library widget (column 1)
   {
+    this->node_library_toggle_button = new QToolButton();
+    this->node_library_toggle_button->setAutoRaise(true);
+    this->node_library_toggle_button->setFixedWidth(16);
+    this->node_library_toggle_button->setSizePolicy(QSizePolicy::Fixed,
+                                                    QSizePolicy::Expanding);
+    this->node_library_toggle_button->setToolTip("Show/hide the node library panel");
+    layout->addWidget(this->node_library_toggle_button, 0, 0, 2, 1);
+
     this->node_library_widget = new NodeLibraryWidget();
-    layout->addWidget(node_library_widget, 0, 0, 2, 1);
-    row_offset++;
+    layout->addWidget(this->node_library_widget, 0, 1, 2, 1);
+
+    this->set_node_library_visible(
+        HSD_CTX.app_settings.node_editor.show_node_library_pan);
   }
 
   // left pan with splitter
@@ -156,7 +175,7 @@ void GraphEditorWidget::setup_layout()
 
     splitter->addWidget(this->graph_node_widget);
 
-    layout->addWidget(splitter, 0, row_offset);
+    layout->addWidget(splitter, 0, 2);
   }
 
   // right pan
@@ -167,7 +186,7 @@ void GraphEditorWidget::setup_layout()
     set_style(this->node_settings_widget,
               std::format("border-left: 1px solid {};", color));
 
-    layout->addWidget(this->node_settings_widget, 0, row_offset + 1, 2, 1);
+    layout->addWidget(this->node_settings_widget, 0, 3, 2, 1);
 
     this->node_settings_widget->setVisible(
         HSD_CTX.app_settings.node_editor.show_node_settings_pan);
@@ -176,7 +195,7 @@ void GraphEditorWidget::setup_layout()
   // bottom toolbar
   {
     auto *graph_toolbar = new GraphToolbar(this->graph_node_widget);
-    layout->addWidget(graph_toolbar, 1, row_offset);
+    layout->addWidget(graph_toolbar, 1, 2);
   }
 
   // --- Connection(s)
@@ -201,6 +220,11 @@ void GraphEditorWidget::setup_layout()
                   &NodeLibraryWidget::node_type_selected_ctrl,
                   this->graph_node_widget,
                   &GraphNodeWidget::on_new_node_request_replace);
+
+    this->connect(this->node_library_toggle_button,
+                  &QToolButton::clicked,
+                  this,
+                  [this]() { Q_EMIT this->node_library_toggle_requested(); });
   }
 }
 

--- a/Hesiod/src/gui/widgets/graph_editor_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_editor_widget.cpp
@@ -3,8 +3,8 @@
  * this software. */
 #include <QGridLayout>
 #include <QSplitter>
-#include <QToolButton>
 #include <QTimer>
+#include <QToolButton>
 
 #include "hesiod/app/hesiod_application.hpp"
 #include "hesiod/gui/widgets/graph_editor_widget.hpp"
@@ -45,17 +45,6 @@ NodeSettingsWidget *GraphEditorWidget::get_node_settings_widget() const
 }
 
 Viewer3D *GraphEditorWidget::get_viewer() const { return this->viewer; }
-
-void GraphEditorWidget::set_node_library_visible(bool new_state)
-{
-  if (this->node_library_widget)
-    this->node_library_widget->setVisible(new_state);
-
-  // arrow points at the panel's collapse direction
-  if (this->node_library_toggle_button)
-    this->node_library_toggle_button->setArrowType(new_state ? Qt::LeftArrow
-                                                             : Qt::RightArrow);
-}
 
 void GraphEditorWidget::json_from(nlohmann::json const &json)
 {
@@ -111,6 +100,17 @@ nlohmann::json GraphEditorWidget::json_to() const
   }
 
   return json;
+}
+
+void GraphEditorWidget::set_node_library_visible(bool new_state)
+{
+  if (this->node_library_widget)
+    this->node_library_widget->setVisible(new_state);
+
+  // arrow points at the panel's collapse direction
+  if (this->node_library_toggle_button)
+    this->node_library_toggle_button->setArrowType(new_state ? Qt::LeftArrow
+                                                             : Qt::RightArrow);
 }
 
 void GraphEditorWidget::setup_connections()

--- a/Hesiod/src/gui/widgets/graph_tabs_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_tabs_widget.cpp
@@ -183,6 +183,13 @@ void GraphTabsWidget::on_node_deleted(const std::string &graph_id, const std::st
   Q_EMIT this->has_changed();
 }
 
+void GraphTabsWidget::set_show_node_library_pan(bool new_state)
+{
+  for (auto &[id, gew] : this->graph_editor_widget_map)
+    if (gew)
+      gew->set_node_library_visible(new_state);
+}
+
 void GraphTabsWidget::set_show_node_settings_widget(bool new_state)
 {
   this->show_node_settings_widget = new_state;
@@ -205,13 +212,6 @@ void GraphTabsWidget::set_show_viewer(bool new_state)
     if (gew && gew->get_viewer())
       gew->get_viewer()->setVisible(show_viewer);
   }
-}
-
-void GraphTabsWidget::set_show_node_library_pan(bool new_state)
-{
-  for (auto &[id, gew] : this->graph_editor_widget_map)
-    if (gew)
-      gew->set_node_library_visible(new_state);
 }
 
 void GraphTabsWidget::set_selected_tab(const std::string &graph_id)

--- a/Hesiod/src/gui/widgets/graph_tabs_widget.cpp
+++ b/Hesiod/src/gui/widgets/graph_tabs_widget.cpp
@@ -207,6 +207,13 @@ void GraphTabsWidget::set_show_viewer(bool new_state)
   }
 }
 
+void GraphTabsWidget::set_show_node_library_pan(bool new_state)
+{
+  for (auto &[id, gew] : this->graph_editor_widget_map)
+    if (gew)
+      gew->set_node_library_visible(new_state);
+}
+
 void GraphTabsWidget::set_selected_tab(const std::string &graph_id)
 {
   for (int i = 0; i < this->tab_widget->count(); ++i)
@@ -354,6 +361,10 @@ void GraphTabsWidget::update_tab_widget()
                   &GraphNodeWidget::update_finished,
                   this,
                   [this]() { emit update_finished(); });
+    this->connect(editor_widget,
+                  &GraphEditorWidget::node_library_toggle_requested,
+                  this,
+                  &GraphTabsWidget::node_library_toggle_requested);
 
     // Create tab container
     QWidget *tab = new QWidget();


### PR DESCRIPTION
As discussed on Discord: the node library stays, but its visibility becomes controllable. A thin full-height arrow strip on the panel's edge collapses/expands it in place (reclaiming canvas space on smaller screens), and a new checkable **View > Show Node Library Panel** entry does the same.

Both controls drive the existing `node_editor.show_node_library_pan` setting — it already existed in `hesiod.json` but was read once at tab construction and exposed nowhere in the UI. The state now applies at runtime (same `set_show_*` pattern as the viewer and node-settings panes), persists across restarts, and stays in sync across graph tabs and with the menu checkbox.

Also relabels "Show Node Settings Pan" → "Show Node Settings Panel" for consistent wording (JSON keys unchanged).

Tested locally (Linux/NixOS, Wayland): strip + menu toggle in both directions, multi-tab sync, node creation from the library, persistence across restart, toggling after loading a project.