### PR TITLE
fix: two crashes on dev — queued attribute sync after node delete, and legacy Array shape conversion

### DIFF
--- a/Hesiod/src/gui/widgets/node_attributes_widget.cpp
+++ b/Hesiod/src/gui/widgets/node_attributes_widget.cpp
@@ -273,6 +273,18 @@ QWidget *NodeAttributesWidget::create_toolbar()
 
 void NodeAttributesWidget::sync_from_model()
 {
+  // This slot is delivered through a queued connection (see setup_layout), so it
+  // can arrive after the node it mirrors has already been removed from the
+  // graph. Meta's sync callbacks capture raw pointers and references into the
+  // node's attribute container, so syncing against a dead node dereferences
+  // freed memory. Drop the stale event instead.
+  auto gno = this->p_graph_node.lock();
+  if (!gno)
+    return;
+
+  if (!gno->get_node_ref_by_id<BaseNode>(this->node_id))
+    return;
+
   if (this->meta_widget)
     this->meta_widget->on_sync_widget_from_model();
 }

--- a/Hesiod/src/model/nodes/legacy/legacy_converter.cpp
+++ b/Hesiod/src/model/nodes/legacy/legacy_converter.cpp
@@ -126,10 +126,17 @@ nlohmann::json convert_legacy_attribute_json(const meta::AbstractAttribute *attr
           vec.resize(expected_size, 0.0f);
         }
 
+        // meta::Array::json_from expects a nested "shape" object (see
+        // Array::json_to); emitting flat "shape.x"/"shape.y" keys leaves the
+        // shape at its reset value of {0, 0}, which silently discards the
+        // vector and yields a zero-sized array downstream.
+        nlohmann::json value = nlohmann::json::object();
+        value["shape"]["x"] = shape_x;
+        value["shape"]["y"] = shape_y;
+        value["vector"] = vec;
+
         converted = nlohmann::json::object();
-        converted["value"] = {{"shape.x", shape_x},
-                              {"shape.y", shape_y},
-                              {"vector", vec}};
+        converted["value"] = value;
       }
       catch (const std::exception &e)
       {


### PR DESCRIPTION
Two independent crashes found while testing `dev` after the Meta integration + GNode event-system merge. Both root-caused with core dumps; each commit has the full analysis in its message.

### 1. Use-after-free deleting a node with an update in flight

`NodeAttributesWidget` subscribes to `post_update_event` and marshals to the GUI thread with a queued `invokeMethod`. Deleting a node whose update is still queued delivers `sync_from_model` *after* the node and its `AttributeContainer` are gone. Meta's widget callbacks hold raw pointers into that container, so the deferred sync dereferences freed memory:

```
meta::AttributeContainer::find (this=0xababffff00000001, name="LinkedSliders.locked_xy")
meta::qt::MetaWidget::sync_widget_from_model
QObject::event
```

Unsubscribing in the destructor can't help — it doesn't cancel already-posted events. The fix guards on delivery, the same way `DataPreview::update_preview` already does for this hazard.

Repro: create `Noise` → `Rifts`, select `Rifts`, delete it.

### 2. Segfault loading any project with a painted Brush

The legacy `Array` converter emitted flat `"shape.x"`/`"shape.y"` keys, but `meta::Array::json_from` reads a nested `"shape"` object (as `Array::json_to` writes). Shape stayed `{0, 0}`, and the size-consistency check then discarded the vector:

```
[meta--] Array size mismatch: shape (0x0) expects 0 elements, but data has 262144 elements.
```

The empty array reached `compute_brush_node` → `resample_to_shape_bilinear` → `std::clamp(is0, 0, -1)`, which is UB and returns `-1`, so `source(-1, -1)` read before the buffer and faulted.

Repro: open `docs/meta-migration/stress/g10.hsd`.

### Testing

Both fixes verified against their repros on Linux/Release. For #2 the `Array size mismatch` warning is gone and the Brush node loads its 512×512 data.

### Related, not fixed here

- `interpolate_array_bilinear` faults on any zero-sized source — `std::clamp(v, 0, -1)` is UB regardless of caller. Worth a defensive guard in HighMap.
- `compute_brush_node` doesn't sanity-check its array either, so a never-painted Brush may still reach the same path.
- Separately: `meta::register_builtin_types()` is never called from Hesiod, so `AttributeFactory`'s registry is empty at runtime and every `create()` during deserialization returns null. Cosmetic today (the dropped keys are stale `compat.*`/`ui.*` metadata), but the compat path is inert. Filing against Meta.
