### PR TITLE
fix(nodes): guard Brush compute against degenerate persisted array data

### DIFF
--- a/Hesiod/src/model/nodes/nodes_function/brush.cpp
+++ b/Hesiod/src/model/nodes/nodes_function/brush.cpp
@@ -43,9 +43,28 @@ void compute_brush_node(BaseNode &node)
   // retrieve raw data and convert them to an hmap::Array
   const auto arr = node.get_meta_group().current().value<meta::Array>("hmap");
 
-  hmap::Array array(arr.shape);
-  array.vector = arr.vector;
-  array        = array.resample_to_shape_bilinear(node.get_config_ref()->shape);
+  // reject degenerate data (e.g. a zero shape persisted by older releases)
+  // instead of resampling an inconsistent array
+  hmap::Array array(node.get_config_ref()->shape);
+
+  if (arr.shape.x <= 0 || arr.shape.y <= 0 ||
+      arr.vector.size() != static_cast<size_t>(arr.shape.x) *
+                               static_cast<size_t>(arr.shape.y))
+  {
+    Logger::log()->error(
+        "Brush node [{}]: invalid heightmap data (shape {}x{}, {} values), "
+        "falling back to a zeroed heightmap",
+        node.get_id(),
+        arr.shape.x,
+        arr.shape.y,
+        arr.vector.size());
+  }
+  else
+  {
+    hmap::Array painted(arr.shape);
+    painted.vector = arr.vector;
+    array          = painted.resample_to_shape_bilinear(node.get_config_ref()->shape);
+  }
 
   // Array -> VirtualArray
   p_out->from_array(array, node.cfg().cm_cpu);


### PR DESCRIPTION
## Problem

A Brush heightmap persisted with a zero (or negative) shape reaches `compute_brush_node` as a 0x0 `meta::Array`. The compute path builds an `hmap::Array` from it and resamples — which segfaults the application. Any project saved while the legacy Array converter emitted flat `shape.x`/`shape.y` keys (before #658) has exactly this persisted `shape {0,0}`, so those files crash on open.

Reproduced: batch mode (`hesiod -b`) on a fixture with `"shape": {"x": 0, "y": 0}` exits with SIGSEGV, dying right after `computing node [Brush]`.

## Fix

Validate the stored array before use: shape strictly positive and `vector.size() == shape.x * shape.y`. On invalid data, log an explicit error naming the node and fall back to a zeroed heightmap at the graph shape, so the rest of the graph keeps computing.

(Related: HighMap dev now guards `interpolate_array_bilinear` against an empty source — otto-link/HighMap#405 — but that guard is not yet in the Hesiod pin, and validating at the node keeps the error actionable regardless.)

## Verification

- zero-shape fixture: was SIGSEGV (exit 139) → now exit 0 with the error logged and a flat output
- negative-shape fixture (`{-1, 512}`): exit 0, guard trips
- `docs/examples/Brush.hsd` (healthy): computes, guard does not trip, no behavior change
- a GUI-saved painted project whose bytes-degenerate vector Meta repairs at load: computes, guard does not trip